### PR TITLE
Own the agents UI as extension widgets on tau's component seam

### DIFF
--- a/HANDOFF-boundary-audit.md
+++ b/HANDOFF-boundary-audit.md
@@ -1,5 +1,14 @@
 # Handoff: audit the tau ↔ tau-subagents boundary
 
+> **Revisited on branch `component-seam-experiment` (2026-07-06).** This audit
+> concludes below that "the pi-style component seam (option 3) was rejected."
+> That decision was reopened as a deliberate experiment: on
+> `component-seam-experiment` the transcript-sources seam is removed from tau
+> core and the strip/viewer are extension-owned Textual widgets on a generic
+> component seam. See `README.md` and the tau repo's
+> `dev-notes/design/component-seam-experiment.md`. The rejection recorded below
+> stands only if the experiment is discarded.
+
 > **RESOLVED (2026-07-06).** The audit ran, a fresh-context reviewer
 > pressure-tested it, and the changes were applied. Verdict: no logic leaks
 > — no `tau_subagents` imports in core, no tool-name special-casing, status

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,16 @@
 # Handoff: fleshing out tau-subagents
 
+> **Superseded on branch `component-seam-experiment` (2026-07-06).** The agents
+> strip / conversation view described below as tau's *transcript-sources* seam
+> (`TranscriptSource`, `set_transcript_source_provider`,
+> `notify_transcript_sources_changed`, `ui.view_transcript`) has been REMOVED
+> from tau core on this branch and re-implemented as extension-owned Textual
+> widgets over a generic *component seam* (`context.ui.components`). See
+> `README.md` ("The agents strip") and, in the tau repo,
+> `dev-notes/design/component-seam-experiment.md`. Sections below that reference
+> the transcript-sources symbols describe the pre-experiment architecture and
+> are accurate again only if this experiment is discarded.
+
 **Mission:** evolve this extension toward feature parity with
 [pi-subagents](https://github.com/tintinweb/pi-subagents) (the extension it
 ports), within the capabilities of Tau's extension system — and extend Tau

--- a/README.md
+++ b/README.md
@@ -70,24 +70,37 @@ headless — it prints the plain-text list instead.
 
 On component-capable Tau builds, spawning a subagent shows a strip under the
 prompt (`AgentStripWidget`) listing `main` plus every queued/running agent (the
-Claude Code pattern), a braille spinner for running runs and each finished
-run's own status glyph. `←`/`↓` in an empty prompt enters the strip; once
-focused it owns `↑`/`↓` navigation, `Enter` opens the selected agent's
-conversation viewer, and `Esc` (or `↑` past the top) hands focus back to the
-prompt. Clicking a row opens it directly.
+Claude Code pattern). Rows are deliberately quiet: a status glyph (a hollow
+circle while running — the spinner/timer/token stats live on the agent
+tool-call row in the main chat, not here) plus the agent type and description.
+
+Navigation is focus-free (pi's fleet-list model): the strip never takes
+keyboard focus — the prompt keeps it throughout, and a pre-dispatch key
+interceptor drives the strip. `←` or `↓` at an empty prompt activates nav;
+`↑`/`↓` then move the selection, `Enter` opens the selected agent's
+conversation viewer, and `Esc` (or `↑` past the top, or typing any other key)
+deactivates nav and returns the keys to the prompt. Clicking a row opens it
+directly.
 
 `Enter` opens the conversation viewer (`ConversationViewer`) in the main area
 as a display-toggled view — the strip stays visible for peripheral fleet
-awareness. It renders the run's live conversation (reusing Tau's own transcript
-rendering), carries a header with label/status/detail, and embeds a steer
-composer: `Enter` opens it, type + `Enter` sends a steering message, `Esc`
-cancels the composer. `x` twice stops the run (a two-press guard), and `Esc`/`q`
-closes the viewer. Live updates are push-based — the viewer subscribes to the
-run's change listeners rather than polling. Finished agents leave the strip
-after a short linger; `/agents` still reaches their transcripts. The agent
-tool-call row in the main transcript shows a braille spinner and a live elapsed
-timer while the run executes (Tau core behavior, driven by this extension's
-`render_call` lines).
+awareness, and nav stays reachable while viewing: `←` re-enters the strip
+(`↓` scrolls the viewer), so you can switch straight to another agent with
+`↑`/`↓` + `Enter`, or select the `main` row and press `Enter` (or click it) to
+close the viewer and return to the main transcript. The viewer renders the
+run's live conversation (reusing Tau's own transcript rendering), carries a
+header with label/status/detail, and embeds a steer composer: `Enter` opens
+it, type + `Enter` sends a steering message, `Esc` cancels the composer. `x`
+twice stops the run (a two-press guard), and `Esc`/`q` closes the viewer. Live
+updates are push-based — the viewer subscribes to the run's change listeners
+rather than polling. Finished agents leave the strip after a short linger;
+`/agents` still reaches their transcripts. The agent tool-call row in the main
+transcript shows a braille spinner and a live elapsed timer while the run
+executes (Tau core behavior, driven by this extension's `render_call` lines).
+
+The UI installs defensively on every `session_start` (any stale controller is
+torn down and fresh widgets mounted), so `/new`, `/resume`, and session
+rebinds always land exactly one strip.
 
 ## Agent types
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Also registers:
 - `get_subagent_result` — poll a background agent, or `wait=true` to block for it
 - `steer_subagent` — inject a message into a running (or queued) agent
 - `/agents` — interactive menu over agent types, runs, and scheduled jobs
-- an **agents strip** under the prompt (Tau builds with the
-  transcript-sources seam): live subagent list with in-place conversation
-  views and steer-by-typing (see "The agents strip")
+- an **agents strip** under the prompt (Tau builds with the component seam):
+  live subagent list with an embedded conversation viewer (see "The agents
+  strip")
 
 ## Install
 
@@ -39,8 +39,9 @@ ln -s ~/code/tau-subagents ~/.tau/extensions/tau-subagents
 
 Update with `git pull`, then restart `tau` (or `/reload`).
 
-No dependencies beyond Tau itself — the extension only imports `tau_agent` /
-`tau_coding` and the standard library.
+Beyond Tau, this branch takes a direct dependency on `textual`: on the
+`component-seam-experiment` branch the agents strip and conversation viewer are
+extension-owned Textual widgets (see "The agents strip").
 
 ## Use
 
@@ -52,27 +53,41 @@ Ask the model to delegate:
 > run it in the background.
 
 `/agents` manages agents. On Tau builds with the `ui-dialogs` seam it opens
-an interactive menu (ported from pi's showAgentsMenu): selecting a run jumps
-into its in-place conversation view (see "The agents strip"), falling back
-to a dialog submenu (view result / steer / stop) on older Tau builds. pi's
-create wizard and settings menu are not
-ported yet. Without the seam — or headless — it prints the plain-text list
-instead.
+an interactive menu (ported from pi's showAgentsMenu): selecting a run opens
+its conversation viewer (see "The agents strip"), falling back to a dialog
+submenu (view result / steer / stop) on hosts without the component seam. pi's
+create wizard and settings menu are not ported yet. Without the seam — or
+headless — it prints the plain-text list instead.
 
 ## The agents strip
 
-On Tau builds with the transcript-sources seam, spawning a subagent shows a
-strip under the prompt listing `main` plus every queued/running agent (the
-Claude Code pattern). `←` in an empty prompt enters the strip (↑/↓ + Enter),
-or click a row: the main transcript swaps to that agent's conversation in
-place — its prompt as the user message, then thinking, tool calls, and
-responses, live-updating while it runs. While a view is open the input talks
-to that agent: submissions become steering messages (the prompt prefix and
-placeholder make the target explicit); Esc returns to main without
-cancelling anything. Finished agents leave the strip — `/agents` still
-reaches their transcripts. The agent tool-call row in the main transcript
-shows a braille spinner and a live elapsed timer while the run executes
-(Tau core behavior, driven by this extension's `render_call` lines).
+> **Experimental (branch `component-seam-experiment`).** On this branch the
+> whole agent UI is owned by the extension as real Textual widgets
+> (`src/tau_subagents/ui/`), mounted through Tau's generic *component seam*
+> (`context.ui.components`: `set_slot_widget` / `open_main_view` /
+> `register_key_interceptor`) rather than Tau core's older transcript-sources
+> seam. Tau core stays agent-agnostic — it only hosts widgets.
+
+On component-capable Tau builds, spawning a subagent shows a strip under the
+prompt (`AgentStripWidget`) listing `main` plus every queued/running agent (the
+Claude Code pattern), a braille spinner for running runs and each finished
+run's own status glyph. `←`/`↓` in an empty prompt enters the strip; once
+focused it owns `↑`/`↓` navigation, `Enter` opens the selected agent's
+conversation viewer, and `Esc` (or `↑` past the top) hands focus back to the
+prompt. Clicking a row opens it directly.
+
+`Enter` opens the conversation viewer (`ConversationViewer`) in the main area
+as a display-toggled view — the strip stays visible for peripheral fleet
+awareness. It renders the run's live conversation (reusing Tau's own transcript
+rendering), carries a header with label/status/detail, and embeds a steer
+composer: `Enter` opens it, type + `Enter` sends a steering message, `Esc`
+cancels the composer. `x` twice stops the run (a two-press guard), and `Esc`/`q`
+closes the viewer. Live updates are push-based — the viewer subscribes to the
+run's change listeners rather than polling. Finished agents leave the strip
+after a short linger; `/agents` still reaches their transcripts. The agent
+tool-call row in the main transcript shows a braille spinner and a live elapsed
+timer while the run executes (Tau core behavior, driven by this extension's
+`render_call` lines).
 
 ## Agent types
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ under Ctrl+O) — the same card family as background completion notifications,
 so foreground and background finishes read alike. Background spawns confirm in
 one line (`⎿ Running in background (agent-1)`).
 
+Esc follows pi's parent-abort semantics: interrupting the main loop while a
+foreground subagent runs cancels the child too (the run settles as
+`∅ cancelled` — neutral, not failure-red — and stays reachable via `/agents`
+and `get_subagent_result`). Background runs are untouched by Esc; they stop
+only via the viewer's `x x`, the `/agents` menu, or session shutdown.
+
 The UI installs defensively on every `session_start` (any stale controller is
 torn down and fresh widgets mounted), so `/new`, `/resume`, and session
 rebinds always land exactly one strip.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ updates are push-based — the viewer subscribes to the run's change listeners
 rather than polling. Finished agents leave the strip after a short linger;
 `/agents` still reaches their transcripts. The agent tool-call row in the main
 transcript shows a braille spinner and a live elapsed timer while the run
-executes (Tau core behavior, driven by this extension's `render_call` lines).
+executes (Tau core behavior, driven by this extension's `render_call` lines),
+plus a cumulative stats ticker (`2 turns · 5 tool uses · 41.2k tokens`)
+streamed through Tau's tool-progress seam. When a foreground run finishes, the
+row renders a completion card via the tool's `render_result` hook — status
+glyph, stats line, and a `⎿` result preview (full result and transcript path
+under Ctrl+O) — the same card family as background completion notifications,
+so foreground and background finishes read alike. Background spawns confirm in
+one line (`⎿ Running in background (agent-1)`).
 
 The UI installs defensively on every `session_start` (any stale controller is
 torn down and fresh widgets mounted), so `/new`, `/resume`, and session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,14 @@ name = "tau-subagents"
 version = "0.1.0"
 description = "Subagents extension for Tau (a port of pi-subagents)."
 requires-python = ">=3.14"
-dependencies = ["tau-ai"]
+# textual is a direct dependency on the component-seam-experiment branch: the
+# extension's agents strip and conversation viewer are real Textual widgets
+# mounted through tau's component seam (previously it reached textual only
+# transitively via tau).
+dependencies = ["tau-ai", "textual>=1.0"]
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = ["pytest>=8.0", "anyio>=4.0"]
 
 # Tau extension manifest (tau branch `extension-manifest`, ported from pi's
 # package.json "pi.extensions"): lets `tau -x` on this repo root find the

--- a/src/tau_subagents/agents_menu.py
+++ b/src/tau_subagents/agents_menu.py
@@ -2,8 +2,8 @@
 
 Driven by Tau's extension UI dialogs (`ui-dialogs` seam: async select /
 confirm / input on `tau.context.ui`). Selecting a run opens its conversation
-in the host's in-place agent view (tau's `view_transcript`, the agents-strip
-seam); hosts without that seam go straight to the action submenu
+in the extension's own conversation viewer via the component seam (the
+`SubagentUiController`); component-less hosts go straight to the action submenu
 (steer / stop / view result). pi's create wizard and settings entries are
 not ported yet.
 
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from .extension import AgentRun, SubagentManager
     from .schedule import SubagentScheduler
     from .schedule_store import ScheduledSubagent
+    from .ui import SubagentUiController
 
 RESULT_PREVIEW_CHARS = 600
 ACTIVE_STATUSES = ("running", "queued")
@@ -58,6 +59,8 @@ async def show_agents_menu(
     manager: SubagentManager,
     ui: DialogUi,
     scheduler: SubagentScheduler | None = None,
+    *,
+    controller: SubagentUiController | None = None,
 ) -> None:
     """Top-level menu (pi's showAgentsMenu): runs, agent types, scheduled jobs."""
     while True:
@@ -78,7 +81,7 @@ async def show_agents_menu(
         if choice is None:
             return
         if choice.startswith("Running agents ("):
-            if await show_running_agents(manager, ui):
+            if await show_running_agents(manager, ui, controller=controller):
                 return
         elif choice.startswith("Agent types ("):
             await show_agent_types(manager, ui)
@@ -88,7 +91,12 @@ async def show_agents_menu(
             return
 
 
-async def show_running_agents(manager: SubagentManager, ui: DialogUi) -> bool:
+async def show_running_agents(
+    manager: SubagentManager,
+    ui: DialogUi,
+    *,
+    controller: SubagentUiController | None = None,
+) -> bool:
     """Run list (pi's showRunningAgents); True when the whole menu should close."""
     while True:
         runs = list(manager.runs.values())
@@ -105,29 +113,30 @@ async def show_running_agents(manager: SubagentManager, ui: DialogUi) -> bool:
             return False
         index = options.index(choice)
         run = runs[index]
-        outcome = await view_run_conversation(ui, run)
+        outcome = view_run_conversation(run, controller)
         if outcome == "exit":
             return True
         if outcome == "actions":
             await show_run_actions(ui, run)
 
 
-async def view_run_conversation(ui: DialogUi, run: AgentRun) -> str:
-    """Open the run's conversation; returns "exit" or "actions".
+def view_run_conversation(
+    run: AgentRun, controller: SubagentUiController | None
+) -> str:
+    """Open the run's conversation via the component seam; "exit" or "actions".
 
-    Uses the host's in-place agent view (tau's `view_transcript`, the
-    agents-strip seam): on success the whole menu closes ("exit") so the
-    user lands in the view. Hosts without the seam — or when the source
-    is gone — go straight to the action submenu ("actions").
+    With a component-capable host the extension opens its own conversation
+    viewer (the widget seam that replaced tau's removed ``view_transcript``):
+    on success the whole menu closes ("exit") so the user lands in the view.
+    Component-less hosts (print mode / older tau) fall to the action submenu
+    ("actions"), exactly as the old ``view_transcript``-missing branch did.
     """
-    view = getattr(ui, "view_transcript", None)
-    if view is not None:
+    if controller is not None:
         try:
-            opened = bool(await view(run.agent_id))
+            if controller.open_conversation(run):
+                return "exit"
         except Exception:  # noqa: BLE001 - degrade to the action submenu
-            opened = False
-        if opened:
-            return "exit"
+            pass
     return "actions"
 
 

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -1124,35 +1124,44 @@ def setup(tau: ExtensionAPI) -> None:
             )
 
         # Live stats ticker: only valid while this tool call is executing, so
-        # foreground-only, cleared before returning.
+        # foreground-only. The try/finally clears it even when tau hard-cancels
+        # this coroutine mid-wait (the run task keeps going and must not keep
+        # ticking into an orphaned callback).
         run.on_update = on_update
         assert run.task is not None
-        while not run.task.done():
-            if signal is not None and signal.is_cancelled():
-                if run.session is not None:
-                    run.session.cancel()
-                run.task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await run.task
-                await manager.close_run(run)
-                run.on_update = None
-                # A cancel that lands before the task first runs never reaches
-                # _run_agent's CancelledError handler; settle the record here
-                # so the roster and the result agree the run is over.
-                if run.status not in TERMINAL_STATUSES:
-                    run.status = "cancelled"
-                if run.completed_at is None:
-                    run.completed_at = time.monotonic()
-                return _tool_result(
-                    "agent",
-                    ok=False,
-                    content="Subagent cancelled",
-                    # Cancelled runs stay in the card family (✗ cancelled).
-                    details=build_notification_details(run, FOREGROUND_RESULT_CHARS),
-                )
-            await asyncio.sleep(0.05)
+        try:
+            while not run.task.done():
+                if signal is not None and signal.is_cancelled():
+                    if run.session is not None:
+                        run.session.cancel()
+                    run.task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await run.task
+                    await manager.close_run(run)
+                    # A cancel that lands before the task first runs never
+                    # reaches _run_agent's CancelledError handler; settle the
+                    # record here so the roster and the result agree.
+                    if run.status not in TERMINAL_STATUSES:
+                        run.status = "cancelled"
+                    if run.completed_at is None:
+                        run.completed_at = time.monotonic()
+                    if run.status in ("completed", "steered"):
+                        # The run beat the cancel to the finish line — report
+                        # the real result, not a phantom cancellation.
+                        return _foreground_result(run)
+                    return _tool_result(
+                        "agent",
+                        ok=False,
+                        content="Subagent cancelled",
+                        # Cancelled runs stay in the card family (✗ cancelled).
+                        details=build_notification_details(
+                            run, FOREGROUND_RESULT_CHARS
+                        ),
+                    )
+                await asyncio.sleep(0.05)
+        finally:
+            run.on_update = None
 
-        run.on_update = None
         return _foreground_result(run)
 
     async def run_resume(agent_id: str, arguments, on_update=None) -> AgentToolResult:  # noqa: ANN001

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tau_agent.messages import UserMessage
 from tau_agent.session import SessionEntry
 from tau_agent.tools import AgentTool, AgentToolResult
 from tau_coding import (
@@ -42,19 +41,12 @@ from tau_coding.extensions import (
     SessionShutdownEvent,
     SessionStartEvent,
 )
-
-try:  # tau's transcript-sources seam (agents strip); older tau lacks it
-    from tau_coding.extensions import TranscriptSource
-except ImportError:  # pragma: no cover - exercised only on older tau branches
-    TranscriptSource = None  # type: ignore[assignment, misc]
 from tau_coding.provider_runtime import create_model_provider
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL, THINKING_LEVELS
 
 from .agents import AgentDefinition, format_agent_type_list, load_agent_definitions
 from .agents_menu import (
-    run_snapshot_messages,
     show_agents_menu,
-    steer_run,
     supports_menu,
 )
 from .group_join import DEFAULT_TIMEOUT, STRAGGLER_TIMEOUT, GroupJoinManager
@@ -92,6 +84,12 @@ GROUP_TIMEOUT_SECONDS = DEFAULT_TIMEOUT
 STRAGGLER_TIMEOUT_SECONDS = STRAGGLER_TIMEOUT
 STALE_AFTER_SECONDS = 600.0
 TERMINAL_STATUSES = ("completed", "steered", "aborted", "error", "cancelled")
+# Event types that change what a viewer would show (session.messages / status).
+# Streaming deltas are skipped: they never touch session.messages, so pushing on
+# them would redraw identical content on every token.
+RUN_PUSH_EVENTS = frozenset(
+    {"message_end", "tool_execution_start", "tool_execution_end", "turn_end", "error"}
+)
 SOFT_LIMIT_MESSAGE = (
     "You have reached your turn limit. Wrap up immediately — provide your"
     " final answer now."
@@ -159,6 +157,12 @@ class AgentRun:
     used_worktree: bool = False
     output_writer: OutputFileWriter | None = None
     output_file: str | None = None
+    # Per-run push listeners (component seam): fired when this run's content or
+    # status changes so an open conversation viewer can re-render. The direct
+    # analog of pi's ``session.subscribe(() => tui.requestRender())``. Safe to
+    # call widget methods from here because runs are asyncio tasks on the TUI
+    # event loop (see the design's push-refresh invariant).
+    listeners: list[Callable[[], None]] = field(default_factory=list)
 
 
 class SubagentManager:
@@ -187,6 +191,12 @@ class SubagentManager:
         if callback is not None:
             with contextlib.suppress(Exception):
                 callback()
+
+    def _notify_run(self, run: AgentRun) -> None:
+        """Fire a run's per-run listeners (viewer push); guarded per listener."""
+        for listener in tuple(run.listeners):
+            with contextlib.suppress(Exception):
+                listener()
 
     @property
     def runs(self) -> dict[str, AgentRun]:
@@ -321,6 +331,7 @@ class SubagentManager:
         run.started_at = time.monotonic()
         run.completed_at = None
         self._notify_sources()
+        self._notify_run(run)
         final_text: list[str] = []
         try:
             async for event in session.prompt(prompt):
@@ -336,6 +347,7 @@ class SubagentManager:
             await self._persist_record(run)
             run.completed_at = time.monotonic()
             self._notify_sources()
+            self._notify_run(run)
 
     async def shutdown(self) -> None:
         self._shutting_down = True
@@ -414,6 +426,7 @@ class SubagentManager:
             await self._finalize_run(run)
             run.completed_at = time.monotonic()
             self._notify_sources()
+            self._notify_run(run)
             if run.background:
                 self._running_background -= 1
                 self._drain_queue()
@@ -634,6 +647,8 @@ class SubagentManager:
         elif event.type == "error" and not event.recoverable:
             run.status = "error"
             run.error = event.message
+        if event.type in RUN_PUSH_EVENTS:
+            self._notify_run(run)
 
     def _deliver_background_result(self, run: AgentRun) -> None:
         if run.result_consumed:
@@ -877,51 +892,6 @@ def _duration_ms(run: AgentRun) -> int | None:
 
 STEER_CALL_PREVIEW_CHARS = 60
 
-# AgentRun statuses → tau's TranscriptSource status vocabulary.
-SOURCE_STATUS = {
-    "running": "running",
-    "queued": "queued",
-    "completed": "done",
-    "steered": "done",
-    "error": "error",
-    "cancelled": "cancelled",
-    "aborted": "cancelled",
-}
-
-
-def run_transcript_source(run: AgentRun):  # noqa: ANN201 - TranscriptSource when available
-    """Map one run onto tau's TranscriptSource (the agents-strip seam)."""
-
-    def messages():  # noqa: ANN202 - tuple[AgentMessage, ...] | None
-        session = run.session
-        if session is not None:
-            try:
-                return tuple(session.messages)
-            except Exception:  # noqa: BLE001 - a closing session must not break the strip
-                return None
-        if run.status == "queued":
-            return (UserMessage(content=run.prompt),)
-        if run.status in TERMINAL_STATUSES:
-            # Session closed or evicted: the run record still tells the story.
-            return run_snapshot_messages(run)
-        return None
-
-    steer = None
-    if run.status in ("running", "queued"):
-
-        def steer(text: str, _run: AgentRun = run) -> None:
-            steer_run(_run, text)
-
-    return TranscriptSource(
-        id=run.agent_id,
-        label=run.agent_type,
-        detail=run.description,
-        status=SOURCE_STATUS.get(run.status, "running"),
-        messages=messages,
-        revision=run.revision,
-        steer=steer,
-    )
-
 
 def render_agent_call(arguments: Mapping[str, object]) -> str:
     """Friendly invocation line for the agent tool (pi's renderCall port)."""
@@ -974,10 +944,37 @@ def setup(tau: ExtensionAPI) -> None:
         except Exception:  # noqa: BLE001 - scheduling must never break the session
             pass
 
+    # Component seam (experimental): the extension owns the agents strip and the
+    # conversation viewer as Textual widgets mounted through the component
+    # bridge. Installed lazily on session_start — NOT in setup() — because the
+    # host attaches its UI bridge (making supports_components True) only after
+    # CodingSession.load has already run setup() with the print-mode NullUiBridge.
+    ui_controller: list[object] = []  # 0 or 1 element (a nonlocal-friendly cell)
+
+    def _install_ui_components() -> None:
+        if ui_controller:
+            return
+        # getattr-guard keeps the extension loadable on an older tau without the
+        # component seam (constraint 8): it then runs dialog-only, no strip.
+        components = getattr(getattr(tau, "context", None), "ui", None)
+        components = getattr(components, "components", None)
+        if components is None or not getattr(components, "supports_components", False):
+            return
+        from .ui import SubagentUiController
+
+        controller = SubagentUiController(manager, components)
+        controller.install()
+        manager.sources_changed = controller.on_change
+        ui_controller.append(controller)
+
+    def _current_controller():  # noqa: ANN202 - SubagentUiController | None
+        return ui_controller[0] if ui_controller else None
+
     async def on_session_start(event: SessionStartEvent) -> None:
         del event
         if not scheduler.is_active():
             start_scheduler()
+        _install_ui_components()
 
     async def run_agent_tool(arguments, signal=None):  # noqa: ANN001, ANN202
         await manager.evict_stale()
@@ -1291,7 +1288,11 @@ def setup(tau: ExtensionAPI) -> None:
                 # loop task (the documented ui-dialogs pattern). Return no
                 # message: any text would open a modal the user must dismiss
                 # before the menu appears.
-                task = loop.create_task(show_agents_menu(manager, ui, scheduler))
+                task = loop.create_task(
+                    show_agents_menu(
+                        manager, ui, scheduler, controller=_current_controller()
+                    )
+                )
                 menu_tasks.add(task)
                 task.add_done_callback(menu_tasks.discard)
                 return None
@@ -1311,6 +1312,12 @@ def setup(tau: ExtensionAPI) -> None:
         # belong to the outgoing transcript and would otherwise leak sessions.
         del event
         scheduler.stop()
+        controller = _current_controller()
+        if controller is not None:
+            # pi parity: the extension clears its own widgets on shutdown (the
+            # host also force-clears as a safety net on the next bridge install).
+            controller.teardown()
+            ui_controller.clear()
         await manager.shutdown()
         manager.runs.clear()
         manager._notify_sources()  # noqa: SLF001 - same-module teardown signal
@@ -1449,16 +1456,6 @@ def setup(tau: ExtensionAPI) -> None:
             render_call=render_steer_call,
         )
     )
-    set_source_provider = getattr(tau, "set_transcript_source_provider", None)
-    if TranscriptSource is not None and callable(set_source_provider):
-
-        def transcript_sources():  # noqa: ANN202 - tuple of TranscriptSource
-            return tuple(
-                run_transcript_source(run) for run in manager.runs.values()
-            )
-
-        set_source_provider(transcript_sources)
-        manager.sources_changed = tau.notify_transcript_sources_changed
     tau.register_command(
         "agents",
         agents_command,

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -353,6 +353,11 @@ class SubagentManager:
             run.context_tokens = session.context_token_estimate
             if run.status == "running":
                 run.status = "completed"
+        except asyncio.CancelledError:
+            # The resume runs inline in the tool coroutine, so a parent Esc
+            # (hard-cancel) lands here; settle the record before re-raising.
+            run.status = "cancelled"
+            raise
         except Exception as exc:  # noqa: BLE001 - report subagent failures as results
             run.status = "error"
             run.error = str(exc)
@@ -1123,28 +1128,32 @@ def setup(tau: ExtensionAPI) -> None:
                 },
             )
 
+        async def cancel_child() -> None:
+            """Stop the child and settle its record (pi's parent-abort cascade)."""
+            if run.session is not None:
+                run.session.cancel()
+            assert run.task is not None
+            run.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await run.task
+            await manager.close_run(run)
+            # A cancel that lands before the task first runs never reaches
+            # _run_agent's CancelledError handler; settle the record here so
+            # the roster and the result agree the run is over.
+            if run.status not in TERMINAL_STATUSES:
+                run.status = "cancelled"
+            if run.completed_at is None:
+                run.completed_at = time.monotonic()
+
         # Live stats ticker: only valid while this tool call is executing, so
         # foreground-only. The try/finally clears it even when tau hard-cancels
-        # this coroutine mid-wait (the run task keeps going and must not keep
-        # ticking into an orphaned callback).
+        # this coroutine mid-wait.
         run.on_update = on_update
         assert run.task is not None
         try:
             while not run.task.done():
                 if signal is not None and signal.is_cancelled():
-                    if run.session is not None:
-                        run.session.cancel()
-                    run.task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await run.task
-                    await manager.close_run(run)
-                    # A cancel that lands before the task first runs never
-                    # reaches _run_agent's CancelledError handler; settle the
-                    # record here so the roster and the result agree.
-                    if run.status not in TERMINAL_STATUSES:
-                        run.status = "cancelled"
-                    if run.completed_at is None:
-                        run.completed_at = time.monotonic()
+                    await cancel_child()
                     if run.status in ("completed", "steered"):
                         # The run beat the cancel to the finish line — report
                         # the real result, not a phantom cancellation.
@@ -1153,12 +1162,22 @@ def setup(tau: ExtensionAPI) -> None:
                         "agent",
                         ok=False,
                         content="Subagent cancelled",
-                        # Cancelled runs stay in the card family (✗ cancelled).
+                        # Cancelled runs stay in the card family (∅ cancelled).
                         details=build_notification_details(
                             run, FOREGROUND_RESULT_CHARS
                         ),
                     )
                 await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            # Esc in the TUI: tau hard-cancels this tool coroutine (the event
+            # stream is torn down before the 50ms poll can see the signal), so
+            # the cooperative branch above never runs. Take the child down
+            # with us — otherwise it keeps running as a zombie and its result
+            # is silently dropped. Background runs are untouched by design:
+            # they never pass through this wait loop (pi wires the parent
+            # abort signal on the foreground path only).
+            await cancel_child()
+            raise
         finally:
             run.on_update = None
 

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -1134,16 +1134,18 @@ def setup(tau: ExtensionAPI) -> None:
                 run.session.cancel()
             assert run.task is not None
             run.task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await run.task
-            await manager.close_run(run)
-            # A cancel that lands before the task first runs never reaches
-            # _run_agent's CancelledError handler; settle the record here so
-            # the roster and the result agree the run is over.
+            # asyncio.wait (not `await run.task`) so the child's CancelledError
+            # is never raised here — a plain suppress would also swallow a
+            # cancellation aimed at THIS coroutine landing at that await.
+            await asyncio.wait({run.task})
+            # Settle before the async close: a cancel that lands before the
+            # task first runs never reaches _run_agent's CancelledError
+            # handler, and a re-cancel during close_run must not skip this.
             if run.status not in TERMINAL_STATUSES:
                 run.status = "cancelled"
             if run.completed_at is None:
                 run.completed_at = time.monotonic()
+            await manager.close_run(run)
 
         # Live stats ticker: only valid while this tool call is executing, so
         # foreground-only. The try/finally clears it even when tau hard-cancels

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -51,7 +51,7 @@ from .agents_menu import (
 )
 from .group_join import DEFAULT_TIMEOUT, STRAGGLER_TIMEOUT, GroupJoinManager
 from .memory import prepare_memory
-from .notification_render import render_notification
+from .notification_render import render_agent_result, render_notification, stat_parts
 from .output_file import OutputFileWriter, output_file_path
 from .prompts import (
     build_child_system_prompt,
@@ -76,6 +76,11 @@ if TYPE_CHECKING:
 
 INDIVIDUAL_RESULT_CHARS = 500
 GROUP_RESULT_CHARS = 300
+# Display-only budget for the foreground card's expanded view (Ctrl+O). More
+# generous than the notification previews above, which also enter the model's
+# context: the old generic result block showed the full text, so a tight cap
+# here would be a regression.
+FOREGROUND_RESULT_CHARS = 6_000
 RECORD_RESULT_CHARS = 4_000
 TRUNCATION_SUFFIX = "\n...(truncated, use get_subagent_result for full output)"
 BATCH_DEBOUNCE_SECONDS = 0.1
@@ -151,6 +156,11 @@ class AgentRun:
     soft_limit_reached: bool = False
     aborted: bool = False
     pending_steers: list[str] = field(default_factory=list)
+    # Live stats ticker (foreground runs only): tau's tool-progress seam, set
+    # for the duration of the blocking tool call. `last_progress` dedups so
+    # the line only repaints when a stat actually changed.
+    on_update: Callable[[str, dict[str, object] | None], None] | None = None
+    last_progress: str = ""
     join_mode: str | None = None
     requested_isolation: str | None = None
     worktree: Worktree | None = None
@@ -650,8 +660,35 @@ class SubagentManager:
         elif event.type == "error" and not event.recoverable:
             run.status = "error"
             run.error = event.message
+        self._emit_progress(run, event)
         if event.type in RUN_PUSH_EVENTS:
             self._notify_run(run)
+
+    def _emit_progress(self, run: AgentRun, event: AgentEvent) -> None:
+        """Update the live stats ticker under the tool row (foreground runs).
+
+        One stable, cumulative line in the completion card's stats vocabulary
+        (turns · tool uses · tokens), so the running row morphs into the
+        finished card — unlike the per-event activity echo this replaces
+        (dropped as noise in d0d5ac8), the line only changes when a stat does.
+        """
+        if run.on_update is None:
+            return
+        if event.type not in ("turn_end", "tool_execution_start", "message_end"):
+            return
+        message = format_live_stats(run)
+        if not message or message == run.last_progress:
+            return
+        run.last_progress = message
+        data: dict[str, object] = {
+            "agent_id": run.agent_id,
+            "turns": run.turns,
+            "tool_uses": run.tool_calls,
+        }
+        if run.has_usage:
+            data["total_tokens"] = lifetime_tokens(run)
+        with contextlib.suppress(Exception):
+            run.on_update(message, data)
 
     def _deliver_background_result(self, run: AgentRun) -> None:
         if run.result_consumed:
@@ -873,6 +910,20 @@ def lifetime_tokens(run: AgentRun) -> int:
     return run.tokens_input + run.tokens_output + run.tokens_cache_write
 
 
+def format_live_stats(run: AgentRun) -> str:
+    """Cumulative running-stats line in the completion card's vocabulary."""
+    return " · ".join(
+        stat_parts(
+            {
+                "turn_count": run.turns,
+                "max_turns": run.max_turns,
+                "tool_uses": run.tool_calls,
+                "total_tokens": lifetime_tokens(run) if run.has_usage else 0,
+            }
+        )
+    )
+
+
 def format_usage_parts(run: AgentRun) -> str:
     """Format pi-style usage parts joined by middle dots."""
     parts = []
@@ -987,13 +1038,13 @@ def setup(tau: ExtensionAPI) -> None:
             start_scheduler()
         _install_ui_components()
 
-    async def run_agent_tool(arguments, signal=None):  # noqa: ANN001, ANN202
+    async def run_agent_tool(arguments, signal=None, *, on_update=None):  # noqa: ANN001, ANN202
         await manager.evict_stale()
         if arguments.get("schedule"):
             return await run_schedule(arguments)
         resume_id = arguments.get("resume")
         if resume_id:
-            return await run_resume(str(resume_id), arguments)
+            return await run_resume(str(resume_id), arguments, on_update)
 
         definitions = manager.definitions()
         agent_type = str(arguments.get("subagent_type", "general"))
@@ -1062,8 +1113,19 @@ def setup(tau: ExtensionAPI) -> None:
                 "agent",
                 ok=True,
                 content=format_background_spawn(run, manager.max_concurrent),
+                # A "background" card: the row confirms the spawn in one dim
+                # line; completion arrives later as a notification card.
+                details={
+                    "status": "background",
+                    "agent_id": run.agent_id,
+                    "queued": run.status == "queued",
+                    "output_file": run.output_file,
+                },
             )
 
+        # Live stats ticker: only valid while this tool call is executing, so
+        # foreground-only, cleared before returning.
+        run.on_update = on_update
         assert run.task is not None
         while not run.task.done():
             if signal is not None and signal.is_cancelled():
@@ -1073,12 +1135,27 @@ def setup(tau: ExtensionAPI) -> None:
                 with contextlib.suppress(asyncio.CancelledError):
                     await run.task
                 await manager.close_run(run)
-                return _tool_result("agent", ok=False, content="Subagent cancelled")
+                run.on_update = None
+                # A cancel that lands before the task first runs never reaches
+                # _run_agent's CancelledError handler; settle the record here
+                # so the roster and the result agree the run is over.
+                if run.status not in TERMINAL_STATUSES:
+                    run.status = "cancelled"
+                if run.completed_at is None:
+                    run.completed_at = time.monotonic()
+                return _tool_result(
+                    "agent",
+                    ok=False,
+                    content="Subagent cancelled",
+                    # Cancelled runs stay in the card family (✗ cancelled).
+                    details=build_notification_details(run, FOREGROUND_RESULT_CHARS),
+                )
             await asyncio.sleep(0.05)
 
+        run.on_update = None
         return _foreground_result(run)
 
-    async def run_resume(agent_id: str, arguments) -> AgentToolResult:  # noqa: ANN001
+    async def run_resume(agent_id: str, arguments, on_update=None) -> AgentToolResult:  # noqa: ANN001
         run = manager.runs.get(agent_id)
         if run is None:
             return _tool_result(
@@ -1109,7 +1186,12 @@ def setup(tau: ExtensionAPI) -> None:
         prompt = str(arguments.get("prompt", "")).strip()
         if not prompt:
             return _tool_result("agent", ok=False, content="prompt is required")
-        await manager.resume(run, prompt)
+        run.on_update = on_update
+        run.last_progress = ""
+        try:
+            await manager.resume(run, prompt)
+        finally:
+            run.on_update = None
         return _foreground_result(run)
 
     async def run_schedule(arguments) -> AgentToolResult:  # noqa: ANN001
@@ -1416,6 +1498,7 @@ def setup(tau: ExtensionAPI) -> None:
             executor=run_agent_tool,
             prompt_snippet="Spawn an autonomous subagent for delegated tasks.",
             render_call=render_agent_call,
+            render_result=render_agent_result,
         )
     )
     tau.register_tool(
@@ -1477,6 +1560,7 @@ def setup(tau: ExtensionAPI) -> None:
 
 
 def _foreground_result(run: AgentRun) -> AgentToolResult:
+    details = build_notification_details(run, FOREGROUND_RESULT_CHARS)
     if run.status in ("completed", "steered"):
         content = run.result_text or "(subagent produced no output)"
         duration = _duration_ms(run)
@@ -1495,11 +1579,13 @@ def _foreground_result(run: AgentRun) -> AgentToolResult:
             "agent",
             ok=True,
             content=f"{format_run_summary(run)}\n{completed_line}\n\n{content}",
+            details=details,
         )
     return _tool_result(
         "agent",
         ok=False,
         content=f"{format_run_summary(run)}\n\n{run.error or 'subagent failed'}",
+        details=details,
     )
 
 
@@ -1509,11 +1595,18 @@ def _coerce_max_turns(value) -> int | None:  # noqa: ANN001
     return int(value)
 
 
-def _tool_result(name: str, *, ok: bool, content: str) -> AgentToolResult:
+def _tool_result(
+    name: str,
+    *,
+    ok: bool,
+    content: str,
+    details: dict | None = None,
+) -> AgentToolResult:
     return AgentToolResult(
         tool_call_id="",
         name=name,
         ok=ok,
         content=content,
+        details=details,
         error=None if ok else content,
     )

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -952,14 +952,22 @@ def setup(tau: ExtensionAPI) -> None:
     ui_controller: list[object] = []  # 0 or 1 element (a nonlocal-friendly cell)
 
     def _install_ui_components() -> None:
-        if ui_controller:
-            return
         # getattr-guard keeps the extension loadable on an older tau without the
         # component seam (constraint 8): it then runs dialog-only, no strip.
         components = getattr(getattr(tau, "context", None), "ui", None)
         components = getattr(components, "components", None)
         if components is None or not getattr(components, "supports_components", False):
             return
+        # Defensive reinstall (bug fix 2): a controller can survive into the next
+        # bind if a session_start arrives without a matching shutdown (or the host
+        # force-cleared its slots on rebind). Tear the stale one down and mount
+        # fresh widgets against the host's current slots. The host sequences the
+        # same-tick teardown+reinstall, so the strip's slot never collides on its
+        # id (which used to raise DuplicateIds and drop the strip).
+        existing = _current_controller()
+        if existing is not None:
+            existing.teardown()
+            ui_controller.clear()
         from .ui import SubagentUiController
 
         controller = SubagentUiController(manager, components)

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -182,8 +182,11 @@ class SubagentManager:
         self._group_join: GroupJoinManager | None = None
         self._worktree_repos: set[str] = set()
         self._nudge_timers: dict[str, asyncio.TimerHandle] = {}
-        # Host signal (tau's transcript-sources seam): fired when the run
-        # list or a run's status changes so the agents strip refreshes.
+        # Roster change signal: fired when the run list or a run's status
+        # changes. On the component seam it is wired (in setup()) to the UI
+        # controller's on_change, which refreshes the extension's own strip
+        # and any open viewer. (The name predates the seam migration: it once
+        # pointed at tau core's removed transcript-sources callback.)
         self.sources_changed: Callable[[], None] | None = None
 
     def _notify_sources(self) -> None:

--- a/src/tau_subagents/notification_render.py
+++ b/src/tau_subagents/notification_render.py
@@ -1,14 +1,24 @@
-"""Custom rendering for <task-notification> messages, ported from pi.
+"""Custom rendering for subagent completions, ported from pi.
 
-Registered as the "subagent-notification" renderer through Tau's
-message-renderers seam (`register_message_renderer`). The renderer reads the
-details dict built by `extension.build_notification_details` (pi's
-buildNotificationDetails) and returns Rich markup; the raw XML content still
-enters the model's context unchanged. Group notifications carry the extra
-runs under details["others"], rendered as stacked blocks like pi.
+Two renderers share one card vocabulary (status glyph, stats line, ⎿ preview,
+transcript path when expanded):
+
+- `render_notification` — the "subagent-notification" message renderer
+  (Tau's message-renderers seam, `register_message_renderer`) for background
+  completions. It reads the details dict built by
+  `extension.build_notification_details` (pi's buildNotificationDetails); the
+  raw XML content still enters the model's context unchanged. Group
+  notifications carry the extra runs under details["others"], rendered as
+  stacked blocks like pi.
+- `render_agent_result` — the agent tool's `render_result` hook (pi's
+  ToolDefinition.renderResult) for foreground completions. It renders the
+  compact card below the tool row's invocation line, so foreground and
+  background finishes read as the same family.
 """
 
 from __future__ import annotations
+
+from rich.markup import escape as _escape
 
 FAILURE_STATUSES = ("error", "stopped", "aborted", "cancelled")
 EXPANDED_RESULT_LINES = 30
@@ -29,42 +39,91 @@ def render_notification(view: object, options: object) -> str | None:
     return "\n".join(rendered) if rendered else None
 
 
+def render_agent_result(result: object, *, expanded: bool) -> str | None:
+    """Render the agent tool's result as a completion card (pi's renderResult).
+
+    The invocation line (`render_call`) stays above; this renders what goes
+    beneath it. Foreground finishes get the compact card — the description is
+    already on the invocation line, so unlike the notification card it is not
+    repeated. Background spawns get a one-line confirmation. ``None`` (no
+    details, e.g. argument-validation failures) falls back to Tau's generic
+    result block.
+    """
+    details = getattr(result, "details", None)
+    if not isinstance(details, dict):
+        return None
+    status = str(details.get("status", ""))
+    if status == "background":
+        verb = "Queued" if details.get("queued") else "Running"
+        agent_id = _escape(str(details.get("agent_id") or "?"))
+        line = f"  [dim]⎿  {verb} in background ({agent_id})[/dim]"
+        output_file = details.get("output_file")
+        if expanded and output_file:
+            line += f"\n  [dim]transcript: {_escape(str(output_file))}[/dim]"
+        return line
+    if not status:
+        return None
+    icon, status_text = _status_glyph(status)
+    line = f"{icon} [dim]" + " · ".join([status_text, *stat_parts(details)]) + "[/dim]"
+    return line + _result_body(details, expanded)
+
+
 def _render_one(details: dict, expanded: bool) -> str:  # noqa: ANN001
     status = str(details.get("status", ""))
-    is_error = status in FAILURE_STATUSES
-    icon = "[red]✗[/red]" if is_error else "[green]✓[/green]"
-    if is_error:
-        status_text = status
-    elif status == "steered":
-        status_text = "completed (steered)"
-    else:
-        status_text = "completed"
+    icon, status_text = _status_glyph(status)
     description = _escape(str(details.get("description", "")))
     line = f"{icon} [bold]{description}[/bold] [dim]{status_text}[/dim]"
 
-    stats = _stat_parts(details)
+    stats = stat_parts(details)
     if stats:
         line += "\n  [dim]" + " · ".join(stats) + "[/dim]"
+    return line + _result_body(details, expanded)
 
+
+def _status_glyph(status: str) -> tuple[str, str]:
+    """Return (icon markup, status text) for a run status."""
+    if status in FAILURE_STATUSES:
+        return "[red]✗[/red]", status
+    if status == "steered":
+        # Wrapped up under a turn limit: a cautionary ✓ (pi's warning color).
+        return "[yellow]✓[/yellow]", "completed (steered)"
+    return "[green]✓[/green]", "completed"
+
+
+def _result_body(details: dict, expanded: bool) -> str:  # noqa: ANN001
+    """The preview/transcript tail shared by both cards.
+
+    Failure previews (the run's error text) render red rather than dim so a
+    failed run doesn't read like routine output.
+    """
     preview = str(details.get("result_preview") or "No output.")
+    style = "red" if str(details.get("status", "")) in FAILURE_STATUSES else "dim"
+    lines = preview.split("\n")
+    body = ""
     if expanded:
-        for preview_line in preview.split("\n")[:EXPANDED_RESULT_LINES]:
-            line += f"\n  [dim]{_escape(preview_line)}[/dim]"
+        for preview_line in lines[:EXPANDED_RESULT_LINES]:
+            body += f"\n  [{style}]{_escape(preview_line)}[/{style}]"
+        hidden = len(lines) - EXPANDED_RESULT_LINES
+        if hidden > 0:
+            body += (
+                f"\n  [dim]… {_plural(hidden, 'more line')}"
+                " — get_subagent_result for full output[/dim]"
+            )
         # The transcript path is long and rarely needed at a glance; it only
         # appears here in the expanded view.
         output_file = details.get("output_file")
         if output_file:
-            line += f"\n  [dim]transcript: {_escape(str(output_file))}[/dim]"
+            body += f"\n  [dim]transcript: {_escape(str(output_file))}[/dim]"
     else:
-        lines = preview.split("\n")
         first = _ellipsize(lines[0], COLLAPSED_PREVIEW_CHARS)
         if len(lines) > 1 and not first.endswith("…"):
             first += "…"
-        line += f"\n  [dim]⎿  {_escape(first)}[/dim]"
-    return line
+        body += f"\n  [{style}]⎿  {_escape(first)}[/{style}]"
+    return body
 
 
-def _stat_parts(details: dict) -> list[str]:  # noqa: ANN001
+def stat_parts(details: dict) -> list[str]:  # noqa: ANN001
+    """Stats vocabulary shared by the cards and the live ticker."""
     parts: list[str] = []
     turns = int(details.get("turn_count") or 0)
     max_turns = details.get("max_turns")
@@ -89,7 +148,7 @@ def _plural(count: int, noun: str) -> str:
 def _format_duration(ms: int) -> str:
     """Match the running tool row's timer: 50.9s under a minute, then 1m 23s."""
     seconds = ms / 1000
-    if seconds < 60:
+    if seconds < 59.95:  # the .1f rounding threshold, so "60.0s" never prints
         return f"{seconds:.1f}s"
     minutes, secs = divmod(int(seconds), 60)
     if minutes < 60:
@@ -113,6 +172,3 @@ def _format_tokens(total: int) -> str:
     return f"{total} tokens"
 
 
-def _escape(text: str) -> str:
-    """Escape Rich markup brackets in run-provided text."""
-    return text.replace("[", r"\[")

--- a/src/tau_subagents/notification_render.py
+++ b/src/tau_subagents/notification_render.py
@@ -128,7 +128,11 @@ def stat_parts(details: dict) -> list[str]:  # noqa: ANN001
     turns = int(details.get("turn_count") or 0)
     max_turns = details.get("max_turns")
     if turns > 0:
-        parts.append(f"{turns}/{max_turns} turns" if max_turns else _plural(turns, "turn"))
+        parts.append(_plural(turns, "turn"))
+        if max_turns:
+            # "(max N)", not "x/N": the limit is a budget, and "3/8" reads
+            # like progress toward a known total.
+            parts[-1] += f" (max {max_turns})"
     tools = int(details.get("tool_uses") or 0)
     if tools > 0:
         parts.append(_plural(tools, "tool use"))

--- a/src/tau_subagents/notification_render.py
+++ b/src/tau_subagents/notification_render.py
@@ -50,13 +50,17 @@ def _render_one(details: dict, expanded: bool) -> str:  # noqa: ANN001
     if expanded:
         for preview_line in preview.split("\n")[:EXPANDED_RESULT_LINES]:
             line += f"\n  [dim]{_escape(preview_line)}[/dim]"
+        # The transcript path is long and rarely needed at a glance; it only
+        # appears here in the expanded view.
+        output_file = details.get("output_file")
+        if output_file:
+            line += f"\n  [dim]transcript: {_escape(str(output_file))}[/dim]"
     else:
-        first = preview.split("\n")[0][:COLLAPSED_PREVIEW_CHARS]
+        lines = preview.split("\n")
+        first = _ellipsize(lines[0], COLLAPSED_PREVIEW_CHARS)
+        if len(lines) > 1 and not first.endswith("…"):
+            first += "…"
         line += f"\n  [dim]⎿  {_escape(first)}[/dim]"
-
-    output_file = details.get("output_file")
-    if output_file:
-        line += f"\n  [dim]transcript: {_escape(str(output_file))}[/dim]"
     return line
 
 
@@ -74,12 +78,33 @@ def _stat_parts(details: dict) -> list[str]:  # noqa: ANN001
         parts.append(_format_tokens(tokens))
     duration = int(details.get("duration_ms") or 0)
     if duration > 0:
-        parts.append(f"{duration / 1000:.1f}s")
+        parts.append(_format_duration(duration))
     return parts
 
 
 def _plural(count: int, noun: str) -> str:
     return f"{count} {noun}{'' if count == 1 else 's'}"
+
+
+def _format_duration(ms: int) -> str:
+    """Match the running tool row's timer: 50.9s under a minute, then 1m 23s."""
+    seconds = ms / 1000
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _ellipsize(text: str, max_chars: int) -> str:
+    """Cut at a word boundary and mark the cut with an ellipsis."""
+    if len(text) <= max_chars:
+        return text
+    cut = text[:max_chars]
+    head, _, _ = cut.rpartition(" ")
+    return (head or cut).rstrip() + "…"
 
 
 def _format_tokens(total: int) -> str:

--- a/src/tau_subagents/notification_render.py
+++ b/src/tau_subagents/notification_render.py
@@ -150,7 +150,8 @@ def _format_duration(ms: int) -> str:
     seconds = ms / 1000
     if seconds < 59.95:  # the .1f rounding threshold, so "60.0s" never prints
         return f"{seconds:.1f}s"
-    minutes, secs = divmod(int(seconds), 60)
+    # round() (not int()) so 59.96s becomes "1m 0s", never "0m 59s".
+    minutes, secs = divmod(round(seconds), 60)
     if minutes < 60:
         return f"{minutes}m {secs}s"
     hours, minutes = divmod(minutes, 60)

--- a/src/tau_subagents/notification_render.py
+++ b/src/tau_subagents/notification_render.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 from rich.markup import escape as _escape
 
 FAILURE_STATUSES = ("error", "stopped", "aborted", "cancelled")
+# User-initiated stops render neutral-dim (pi's "■ Stopped"), not failure-red:
+# the user asked for it, nothing went wrong.
+USER_STOP_STATUSES = ("cancelled", "stopped")
 EXPANDED_RESULT_LINES = 30
 COLLAPSED_PREVIEW_CHARS = 80
 
@@ -82,6 +85,9 @@ def _render_one(details: dict, expanded: bool) -> str:  # noqa: ANN001
 
 def _status_glyph(status: str) -> tuple[str, str]:
     """Return (icon markup, status text) for a run status."""
+    if status in USER_STOP_STATUSES:
+        # ∅ matches the fleet strip's cancelled glyph.
+        return "[dim]∅[/dim]", status
     if status in FAILURE_STATUSES:
         return "[red]✗[/red]", status
     if status == "steered":
@@ -97,7 +103,9 @@ def _result_body(details: dict, expanded: bool) -> str:  # noqa: ANN001
     failed run doesn't read like routine output.
     """
     preview = str(details.get("result_preview") or "No output.")
-    style = "red" if str(details.get("status", "")) in FAILURE_STATUSES else "dim"
+    status = str(details.get("status", ""))
+    is_failure = status in FAILURE_STATUSES and status not in USER_STOP_STATUSES
+    style = "red" if is_failure else "dim"
     lines = preview.split("\n")
     body = ""
     if expanded:

--- a/src/tau_subagents/ui/__init__.py
+++ b/src/tau_subagents/ui/__init__.py
@@ -1,0 +1,17 @@
+"""Extension-owned Textual widgets for the subagents fleet UI.
+
+This package is the extension side of tau's *component seam* (branch
+``component-seam-experiment``): the agents strip and the conversation viewer
+that used to live in tau core are now real Textual ``Widget``s that the
+extension mounts through ``context.ui.components``. Importing ``textual`` (and,
+in the viewer, a couple of tau TUI internals) directly is the deliberate
+coupling this experiment measures.
+"""
+
+from __future__ import annotations
+
+from .controller import SubagentUiController
+from .strip import AgentStripWidget
+from .viewer import ConversationViewer
+
+__all__ = ["AgentStripWidget", "ConversationViewer", "SubagentUiController"]

--- a/src/tau_subagents/ui/controller.py
+++ b/src/tau_subagents/ui/controller.py
@@ -1,0 +1,131 @@
+"""Wires the extension's Textual widgets onto tau's component seam.
+
+Holds the fleet strip and the (at most one) open conversation viewer, registers
+the strip slot widget + the key interceptor that ENTERS the strip, and repoints
+the manager's change signal at a push that refreshes the strip and any open
+viewer. All host access goes through the :class:`ComponentBridge`
+(``context.ui.components``); nothing here touches tau internals directly beyond
+the widgets it mounts.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Callable
+
+from .strip import AgentStripWidget
+from .viewer import ConversationViewer
+
+if TYPE_CHECKING:
+    from textual import events
+    from tau_coding.extensions import ComponentBridge
+    from tau_coding.tui.config import TuiTheme
+
+    from ..extension import AgentRun, SubagentManager
+
+STRIP_KEY = "subagents-fleet"
+
+
+class SubagentUiController:
+    """Owns the fleet strip + conversation viewer against the component bridge."""
+
+    def __init__(self, manager: SubagentManager, components: ComponentBridge) -> None:
+        self._manager = manager
+        self._components = components
+        self._strip: AgentStripWidget | None = None
+        self._viewer: ConversationViewer | None = None
+        self._viewing_id: str | None = None
+        self._unsub_interceptor: Callable[[], None] | None = None
+
+    # ---- Install / teardown ----------------------------------------------
+
+    def install(self) -> None:
+        """Mount the strip slot and register the strip-entry key interceptor."""
+        self._components.set_slot_widget(
+            STRIP_KEY, self._build_strip, placement="below_prompt"
+        )
+        self._unsub_interceptor = self._components.register_key_interceptor(
+            self._intercept_key
+        )
+
+    def teardown(self) -> None:
+        """Remove the strip, close any viewer, and drop the interceptor."""
+        if self._unsub_interceptor is not None:
+            with contextlib.suppress(Exception):
+                self._unsub_interceptor()
+            self._unsub_interceptor = None
+        with contextlib.suppress(Exception):
+            self._components.set_slot_widget(STRIP_KEY, None, placement="below_prompt")
+        self._strip = None
+        self._viewer = None
+        self._viewing_id = None
+
+    def _build_strip(self, theme: TuiTheme) -> AgentStripWidget:
+        strip = AgentStripWidget(
+            self._manager, theme, open_conversation=self.open_conversation
+        )
+        strip.viewing_id = self._viewing_id
+        self._strip = strip
+        return strip
+
+    # ---- Push -------------------------------------------------------------
+
+    def on_change(self) -> None:
+        """Manager change signal: refresh the strip and any open viewer."""
+        if self._strip is not None:
+            self._strip.refresh_roster()
+        if self._viewer is not None:
+            self._viewer.on_external_change()
+
+    # ---- Viewer -----------------------------------------------------------
+
+    def open_conversation(self, run: AgentRun) -> bool:
+        """Open the run's conversation in the main-area view. False if unsupported."""
+        if not self._components.supports_components:
+            return False
+        self._viewing_id = run.agent_id
+        if self._strip is not None:
+            self._strip.viewing_id = run.agent_id
+            self._strip.refresh_roster()
+
+        def build(handle, theme: TuiTheme) -> ConversationViewer:
+            viewer = ConversationViewer(
+                run,
+                handle,
+                self._manager,
+                theme,
+            )
+            # Identity-checked close: a superseded viewer's (deferred) unmount
+            # must not clobber a newer viewer opened in its place.
+            viewer.on_close = lambda: self._on_viewer_closed(viewer)
+            self._viewer = viewer
+            return viewer
+
+        self._components.open_main_view(build)
+        return True
+
+    def _on_viewer_closed(self, viewer: ConversationViewer) -> None:
+        if self._viewer is not viewer:
+            return
+        self._viewer = None
+        self._viewing_id = None
+        if self._strip is not None:
+            self._strip.viewing_id = None
+            self._strip.refresh_roster()
+
+    # ---- Key interceptor (enter the strip only) ---------------------------
+
+    def _intercept_key(self, event: events.Key, prompt_text: str) -> bool:
+        """Enter the strip on left/down at an empty prompt (pi's activation gate).
+
+        The interceptor fires only while the prompt is focused, so it is used
+        solely to hand focus INTO the strip; once focused the strip owns its own
+        navigation via its ``on_key``.
+        """
+        strip = self._strip
+        if strip is None or prompt_text != "":
+            return False
+        if event.key in ("down", "left") and strip.has_agents():
+            strip.enter_strip()
+            return True
+        return False

--- a/src/tau_subagents/ui/controller.py
+++ b/src/tau_subagents/ui/controller.py
@@ -63,7 +63,10 @@ class SubagentUiController:
 
     def _build_strip(self, theme: TuiTheme) -> AgentStripWidget:
         strip = AgentStripWidget(
-            self._manager, theme, open_conversation=self.open_conversation
+            self._manager,
+            theme,
+            open_conversation=self.open_conversation,
+            close_conversation=self.close_conversation,
         )
         strip.viewing_id = self._viewing_id
         self._strip = strip
@@ -108,6 +111,19 @@ class SubagentUiController:
         self._components.open_main_view(build)
         return True
 
+    def close_conversation(self) -> bool:
+        """Close the open viewer via its host handle. False if none is open.
+
+        The viewer's ``on_unmount`` calls back into ``_on_viewer_closed``, which
+        clears the ● marker and restores the strip; the host handle restores the
+        main transcript and prompt focus.
+        """
+        viewer = self._viewer
+        if viewer is None:
+            return False
+        viewer.request_close()
+        return True
+
     def _on_viewer_closed(self, viewer: ConversationViewer) -> None:
         if self._viewer is not viewer:
             return
@@ -124,27 +140,39 @@ class SubagentUiController:
 
         The host consults this pre-dispatch, before its app-level priority
         bindings and the focused widget, so the strip never needs focus. Gated
-        on: a mounted strip with agents, no viewer open (a viewer/composer owns
-        real focus and its own keys), and an empty prompt (typing flows through).
+        on a mounted strip with agents; it stays active even while a viewer is
+        open (so the user can navigate back to ``main`` or another run) EXCEPT
+        while the steer composer owns the keyboard.
 
-        Keys: while inactive, ``down``/``left`` activate nav (highlight ``main``).
-        While active, ``down``/``up`` move the selection (up past the top
-        deactivates), ``enter`` activates the row (``main`` → deactivate; an agent
-        → open its viewer), ``escape`` deactivates. Any other key deactivates and
-        is NOT consumed, so it flows to the prompt naturally (pi parity).
+        Keys — no viewer open: while inactive, ``down``/``left`` at an empty
+        prompt activate nav; typing flows through. Viewer open: ``left`` (only,
+        not ``down`` — the focused viewer scrolls with ``up``/``down``) activates
+        nav. While active: ``down``/``up`` move the selection (up past the top
+        deactivates), ``escape`` deactivates, ``enter`` on ``main`` closes any
+        open viewer and deactivates, ``enter`` on an agent opens/switches its
+        viewer; any other key deactivates and is NOT consumed (pi parity).
         """
         strip = self._strip
-        # Yield entirely while a viewer/composer is open — it owns focus + keys.
-        if strip is None or self._viewer is not None or not strip.has_agents():
+        if strip is None or not strip.has_agents():
             return False
-        if prompt_text != "":
-            # The user is typing; make sure a stale nav highlight is cleared.
+        viewer = self._viewer
+        # While the steer composer is focused, yield entirely — it owns keys.
+        if viewer is not None and viewer.composer_active:
+            return False
+        if viewer is None and prompt_text != "":
+            # The user is typing at the prompt; clear any stale nav highlight.
             if strip.nav_active:
                 strip.deactivate_nav()
             return False
 
         key = event.key
         if not strip.nav_active:
+            if viewer is not None:
+                # Viewer open: only `left` enters the strip; `down` scrolls it.
+                if key == "left":
+                    strip.activate_nav()
+                    return True
+                return False
             if key in ("down", "left"):
                 strip.activate_nav()
                 return True
@@ -166,11 +194,14 @@ class SubagentUiController:
         if key == "enter":
             run = strip.selected_run()
             if run is None:
-                strip.deactivate_nav()  # main row: just return to the prompt
+                # main row: close any open viewer, then return to the prompt.
+                self.close_conversation()
+                strip.deactivate_nav()
             else:
+                # Open or switch (race-safe: the host sequences the swap).
                 self.open_conversation(run)
             return True
 
-        # Any other key: cancel nav and let it flow to the prompt (pi parity).
+        # Any other key: cancel nav and let it flow (pi parity).
         strip.deactivate_nav()
         return False

--- a/src/tau_subagents/ui/controller.py
+++ b/src/tau_subagents/ui/controller.py
@@ -1,9 +1,10 @@
 """Wires the extension's Textual widgets onto tau's component seam.
 
 Holds the fleet strip and the (at most one) open conversation viewer, registers
-the strip slot widget + the key interceptor that ENTERS the strip, and repoints
-the manager's change signal at a push that refreshes the strip and any open
-viewer. All host access goes through the :class:`ComponentBridge`
+the strip slot widget + the pre-dispatch key interceptor that owns the strip's
+whole navigation state machine (pi's fleet-list model; the strip never takes
+focus), and repoints the manager's change signal at a push that refreshes the
+strip and any open viewer. All host access goes through the :class:`ComponentBridge`
 (``context.ui.components``); nothing here touches tau internals directly beyond
 the widgets it mounts.
 """
@@ -40,7 +41,7 @@ class SubagentUiController:
     # ---- Install / teardown ----------------------------------------------
 
     def install(self) -> None:
-        """Mount the strip slot and register the strip-entry key interceptor."""
+        """Mount the strip slot and register the nav key interceptor."""
         self._components.set_slot_widget(
             STRIP_KEY, self._build_strip, placement="below_prompt"
         )
@@ -86,6 +87,9 @@ class SubagentUiController:
         self._viewing_id = run.agent_id
         if self._strip is not None:
             self._strip.viewing_id = run.agent_id
+            # Nav state resets when a viewer opens: the interceptor yields while a
+            # viewer is up, so leaving nav active would strand a highlight.
+            self._strip.deactivate_nav()
             self._strip.refresh_roster()
 
         def build(handle, theme: TuiTheme) -> ConversationViewer:
@@ -113,19 +117,60 @@ class SubagentUiController:
             self._strip.viewing_id = None
             self._strip.refresh_roster()
 
-    # ---- Key interceptor (enter the strip only) ---------------------------
+    # ---- Key interceptor (owns the whole nav state machine) ---------------
 
     def _intercept_key(self, event: events.Key, prompt_text: str) -> bool:
-        """Enter the strip on left/down at an empty prompt (pi's activation gate).
+        """Drive strip navigation, pi's fleet-list model, from the prompt.
 
-        The interceptor fires only while the prompt is focused, so it is used
-        solely to hand focus INTO the strip; once focused the strip owns its own
-        navigation via its ``on_key``.
+        The host consults this pre-dispatch, before its app-level priority
+        bindings and the focused widget, so the strip never needs focus. Gated
+        on: a mounted strip with agents, no viewer open (a viewer/composer owns
+        real focus and its own keys), and an empty prompt (typing flows through).
+
+        Keys: while inactive, ``down``/``left`` activate nav (highlight ``main``).
+        While active, ``down``/``up`` move the selection (up past the top
+        deactivates), ``enter`` activates the row (``main`` → deactivate; an agent
+        → open its viewer), ``escape`` deactivates. Any other key deactivates and
+        is NOT consumed, so it flows to the prompt naturally (pi parity).
         """
         strip = self._strip
-        if strip is None or prompt_text != "":
+        # Yield entirely while a viewer/composer is open — it owns focus + keys.
+        if strip is None or self._viewer is not None or not strip.has_agents():
             return False
-        if event.key in ("down", "left") and strip.has_agents():
-            strip.enter_strip()
+        if prompt_text != "":
+            # The user is typing; make sure a stale nav highlight is cleared.
+            if strip.nav_active:
+                strip.deactivate_nav()
+            return False
+
+        key = event.key
+        if not strip.nav_active:
+            if key in ("down", "left"):
+                strip.activate_nav()
+                return True
+            return False
+
+        # Nav is active.
+        if key == "down":
+            strip.move_selection(1)
             return True
+        if key == "up":
+            if strip.selected_index == 0:
+                strip.deactivate_nav()
+            else:
+                strip.move_selection(-1)
+            return True
+        if key == "escape":
+            strip.deactivate_nav()
+            return True
+        if key == "enter":
+            run = strip.selected_run()
+            if run is None:
+                strip.deactivate_nav()  # main row: just return to the prompt
+            else:
+                self.open_conversation(run)
+            return True
+
+        # Any other key: cancel nav and let it flow to the prompt (pi parity).
+        strip.deactivate_nav()
         return False

--- a/src/tau_subagents/ui/strip.py
+++ b/src/tau_subagents/ui/strip.py
@@ -2,8 +2,10 @@
 
 Ports pi-subagents' ``fleet-list.ts`` onto tau's component seam, blended with
 the rendering feel of tau core's old ``_render_agent_strip``. One row for
-``main`` plus one per active/lingering run; a braille spinner marks running
-runs and richer statuses (``steered``/``aborted``) render their own glyph
+``main`` plus one per active/lingering run. Rows stay deliberately quiet: a
+status glyph (hollow circle while running — the spinner/timer/token stats
+live on the agent tool row in the main chat, not here) plus type and
+description; richer statuses (``steered``/``aborted``) render their own glyph
 directly (no down-mapping onto the old five-status vocabulary).
 
 Navigation follows pi's fleet-list model. The strip NEVER takes Textual focus:
@@ -37,47 +39,24 @@ STRIP_MAX_ROWS = 4
 # How long a finished run lingers in the strip before it drops off (pi's
 # FINISHED_LINGER_MS). It stays reachable via /agents afterwards.
 FINISHED_LINGER_SECONDS = 4.0
-# Re-render cadence so the running spinner animates and lingering rows expire.
-SPINNER_INTERVAL = 0.2
-_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+# Re-render cadence so lingering rows expire on time.
+TICK_INTERVAL = 0.5
 
 ACTIVE_STATUSES = ("running", "queued")
 
-# AgentRun status → strip glyph. "running" is special-cased (spinner); the rest
-# render directly, so steered/aborted keep their own identity (the seam review's
-# "no more down-mapping").
+# AgentRun status → strip glyph. Every status renders directly, so
+# steered/aborted keep their own identity (the seam review's "no more
+# down-mapping"). Running is a hollow circle — the animated spinner belongs
+# to the agent tool row in the main chat, not the strip.
 STATUS_GLYPHS = {
     "queued": "◌",
+    "running": "○",
     "completed": "✓",
     "steered": "↻",
     "aborted": "⊘",
     "error": "✗",
     "cancelled": "∅",
 }
-
-
-def _lifetime_tokens(run: AgentRun) -> int:
-    """Lifetime billed tokens (mirrors extension.lifetime_tokens without importing it)."""
-    return run.tokens_input + run.tokens_output + run.tokens_cache_write
-
-
-def format_elapsed(run: AgentRun) -> str:
-    """`11s` — integer seconds, freezing once the run finishes (pi parity)."""
-    if run.started_at is None:
-        return "queued"
-    end = run.completed_at if run.completed_at is not None else time.monotonic()
-    return f"{max(0, round(end - run.started_at))}s"
-
-
-def format_tokens(count: int) -> str:
-    """`↓ 13.1k tokens` — compact magnitude with a down-arrow prefix (pi parity)."""
-    if count >= 1_000_000:
-        compact = f"{count / 1_000_000:.1f}M"
-    elif count >= 1_000:
-        compact = f"{count / 1_000:.1f}k"
-    else:
-        compact = str(count)
-    return f"↓ {compact} tokens"
 
 
 class AgentStripWidget(Static):
@@ -113,7 +92,6 @@ class AgentStripWidget(Static):
         # 0 = main, 1..N = the agent at roster position N.
         self._selected_index = 0
         self._focused_nav = False
-        self._spinner_frame = 0
         # id of the run whose viewer is currently open (● accent marker).
         self.viewing_id: str | None = None
         # Populated each render() so on_click can map a line offset back to a run
@@ -123,18 +101,16 @@ class AgentStripWidget(Static):
     # ---- Lifecycle --------------------------------------------------------
 
     def on_mount(self) -> None:
-        """Start the spinner/linger tick; refresh reflects live manager state."""
-        self.set_interval(SPINNER_INTERVAL, self._tick)
+        """Start the linger tick; refresh reflects live manager state."""
+        self.set_interval(TICK_INTERVAL, self._tick)
 
     def _tick(self) -> None:
-        """Advance the spinner and re-render (cheap; render reads live state).
+        """Re-render so lingering rows expire on time (render reads live state).
 
         Uses ``layout=True`` because a lingering run can expire between ticks,
         shrinking the row count — a plain ``refresh()`` would leave a stale
         height (the same class of bug as the mount-empty case).
         """
-        if self._agent_runs():
-            self._spinner_frame = (self._spinner_frame + 1) % len(_SPINNER_FRAMES)
         self.refresh(layout=True)
 
     def refresh_roster(self) -> None:
@@ -297,8 +273,6 @@ class AgentStripWidget(Static):
         return Group(*rows)
 
     def _glyph_for(self, run: AgentRun) -> str:
-        if run.status == "running":
-            return _SPINNER_FRAMES[self._spinner_frame]
         return STATUS_GLYPHS.get(run.status, "○")
 
     def _render_row(
@@ -334,10 +308,4 @@ class AgentStripWidget(Static):
         row.append(label, style=f"bold {label_style}" if selected else label_style)
         if detail:
             row.append(f"  {detail}", style=theme.muted_text)
-        if run is not None:
-            tokens = _lifetime_tokens(run)
-            stat = format_elapsed(run)
-            if run.has_usage and tokens:
-                stat += f" · {format_tokens(tokens)}"
-            row.append(f"  {stat}", style=theme.muted_text)
         return row

--- a/src/tau_subagents/ui/strip.py
+++ b/src/tau_subagents/ui/strip.py
@@ -101,11 +101,15 @@ class AgentStripWidget(Static):
         theme: TuiTheme,
         *,
         open_conversation: Callable[[AgentRun], bool],
+        close_conversation: Callable[[], bool] | None = None,
     ) -> None:
         super().__init__("", id="subagents-fleet-strip")
         self._manager = manager
         self._theme = theme
         self._open_conversation = open_conversation
+        # Closes an open viewer if one is up; returns True if it did. Lets the
+        # `main` row double as "back to main" while a viewer is open.
+        self._close_conversation = close_conversation
         # 0 = main, 1..N = the agent at roster position N.
         self._selected_index = 0
         self._focused_nav = False
@@ -218,13 +222,15 @@ class AgentStripWidget(Static):
     def on_click(self, event: events.Click) -> None:
         """Click a row to open its viewer; needs no focus (pi/tau parity).
 
-        The ``main`` row just deactivates nav; an agent row selects and opens.
+        The ``main`` row closes an open viewer (back to main), else deactivates
+        nav; an agent row selects and opens.
         """
         line = int(event.y)
         if 0 <= line < len(self._row_runs):
             run = self._row_runs[line]
             if run is None:
-                self.deactivate_nav()
+                if self._close_conversation is None or not self._close_conversation():
+                    self.deactivate_nav()
                 return
             # Reflect the click in the selection, then open.
             agents = self._agent_runs()

--- a/src/tau_subagents/ui/strip.py
+++ b/src/tau_subagents/ui/strip.py
@@ -1,0 +1,342 @@
+"""The fleet strip: a below-prompt slot widget listing active subagent runs.
+
+Ports pi-subagents' ``fleet-list.ts`` onto tau's component seam, blended with
+the rendering feel of tau core's old ``_render_agent_strip``. One row for
+``main`` plus one per active/lingering run; a braille spinner marks running
+runs and richer statuses (``steered``/``aborted``) render their own glyph
+directly (no down-mapping onto the old five-status vocabulary).
+
+Navigation follows the seam review's ruling: the extension's key interceptor
+(registered by :class:`~tau_subagents.ui.controller.SubagentUiController`) only
+ENTERS the strip — ``left``/``down`` at an empty prompt. Once the strip has
+Textual focus it owns its own nav via :meth:`on_key`; ``esc`` / up-past-top
+returns focus to the prompt. ``Enter`` (or a click) on an agent row opens the
+conversation viewer; the ``main`` row just returns to the prompt.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Callable
+
+from rich.console import Group
+from rich.text import Text
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from textual import events
+    from tau_coding.tui.config import TuiTheme
+
+    from ..extension import AgentRun, SubagentManager
+
+# Max agent rows shown at once; extras collapse into a "… N more — /agents" line
+# (matches tau core's AGENT_STRIP_MAX_ROWS).
+STRIP_MAX_ROWS = 4
+# How long a finished run lingers in the strip before it drops off (pi's
+# FINISHED_LINGER_MS). It stays reachable via /agents afterwards.
+FINISHED_LINGER_SECONDS = 4.0
+# Re-render cadence so the running spinner animates and lingering rows expire.
+SPINNER_INTERVAL = 0.2
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+ACTIVE_STATUSES = ("running", "queued")
+
+# AgentRun status → strip glyph. "running" is special-cased (spinner); the rest
+# render directly, so steered/aborted keep their own identity (the seam review's
+# "no more down-mapping").
+STATUS_GLYPHS = {
+    "queued": "◌",
+    "completed": "✓",
+    "steered": "↻",
+    "aborted": "⊘",
+    "error": "✗",
+    "cancelled": "∅",
+}
+
+
+def _lifetime_tokens(run: AgentRun) -> int:
+    """Lifetime billed tokens (mirrors extension.lifetime_tokens without importing it)."""
+    return run.tokens_input + run.tokens_output + run.tokens_cache_write
+
+
+def format_elapsed(run: AgentRun) -> str:
+    """`11s` — integer seconds, freezing once the run finishes (pi parity)."""
+    if run.started_at is None:
+        return "queued"
+    end = run.completed_at if run.completed_at is not None else time.monotonic()
+    return f"{max(0, round(end - run.started_at))}s"
+
+
+def format_tokens(count: int) -> str:
+    """`↓ 13.1k tokens` — compact magnitude with a down-arrow prefix (pi parity)."""
+    if count >= 1_000_000:
+        compact = f"{count / 1_000_000:.1f}M"
+    elif count >= 1_000:
+        compact = f"{count / 1_000:.1f}k"
+    else:
+        compact = str(count)
+    return f"↓ {compact} tokens"
+
+
+class AgentStripWidget(Static):
+    """Focusable below-prompt widget showing ``main`` + active subagent runs."""
+
+    # A slot widget must be focusable so it can own keyboard nav once entered.
+    can_focus = True
+
+    DEFAULT_CSS = """
+    AgentStripWidget {
+        height: auto;
+        max-height: 8;
+    }
+    """
+
+    def __init__(
+        self,
+        manager: SubagentManager,
+        theme: TuiTheme,
+        *,
+        open_conversation: Callable[[AgentRun], bool],
+    ) -> None:
+        super().__init__("", id="subagents-fleet-strip")
+        self._manager = manager
+        self._theme = theme
+        self._open_conversation = open_conversation
+        # 0 = main, 1..N = the agent at roster position N.
+        self._selected_index = 0
+        self._focused_nav = False
+        self._spinner_frame = 0
+        # id of the run whose viewer is currently open (● accent marker).
+        self.viewing_id: str | None = None
+        # Populated each render() so on_click can map a line offset back to a run
+        # (None marks the main row / non-row lines).
+        self._row_runs: list[AgentRun | None] = []
+
+    # ---- Lifecycle --------------------------------------------------------
+
+    def on_mount(self) -> None:
+        """Start the spinner/linger tick; refresh reflects live manager state."""
+        self.set_interval(SPINNER_INTERVAL, self._tick)
+
+    def _tick(self) -> None:
+        """Advance the spinner and re-render (cheap; render reads live state)."""
+        if self._agent_runs():
+            self._spinner_frame = (self._spinner_frame + 1) % len(_SPINNER_FRAMES)
+        self.refresh()
+
+    def refresh_roster(self) -> None:
+        """Re-render after the run list or a status changed (controller push)."""
+        self.refresh()
+
+    # ---- Roster -----------------------------------------------------------
+
+    def _agent_runs(self) -> list[AgentRun]:
+        """Runs shown in the strip, earliest-launched first (pi's agentRecords()).
+
+        Included: running/queued, the currently-viewed run, and recently-finished
+        runs during their linger window. Finished runs then drop off (still
+        reachable via /agents).
+        """
+        now = time.monotonic()
+        runs = [
+            run
+            for run in self._manager.runs.values()
+            if run.status in ACTIVE_STATUSES
+            or run.agent_id == self.viewing_id
+            or (
+                run.completed_at is not None
+                and now - run.completed_at < FINISHED_LINGER_SECONDS
+            )
+        ]
+        runs.sort(key=lambda run: (run.started_at if run.started_at is not None else 0.0))
+        return runs
+
+    def has_agents(self) -> bool:
+        """Whether the strip currently has any agent row (gates strip entry)."""
+        return bool(self._agent_runs())
+
+    def _roster_len(self) -> int:
+        """Total selectable rows: main + agents."""
+        return 1 + len(self._agent_runs())
+
+    # ---- Entry / focus ----------------------------------------------------
+
+    def enter_strip(self) -> None:
+        """Take keyboard focus and start navigating from the top (main)."""
+        self._focused_nav = True
+        self._selected_index = 0
+        self.focus()
+        self.refresh()
+
+    def _exit_to_prompt(self) -> None:
+        """Return focus to the prompt (host-owned ``#prompt``; noted coupling)."""
+        self._focused_nav = False
+        self._selected_index = 0
+        # The strip is a real Textual widget, so it reaches the host prompt by id.
+        # This is the extension→host coupling the component-seam experiment records.
+        try:
+            self.app.query_one("#prompt").focus()
+        except Exception:  # noqa: BLE001 - never let a focus miss crash nav
+            pass
+        self.refresh()
+
+    def on_blur(self) -> None:
+        """Drop the nav highlight when focus leaves the strip by any route."""
+        self._focused_nav = False
+        self.refresh()
+
+    # ---- Keyboard nav (only while the strip holds focus) ------------------
+
+    def on_key(self, event: events.Key) -> None:
+        """Own navigation while focused; esc / up-past-top hands back to prompt."""
+        key = event.key
+        if key == "down":
+            event.stop()
+            event.prevent_default()
+            self._selected_index = min(self._roster_len() - 1, self._selected_index + 1)
+            self.refresh()
+        elif key == "up":
+            event.stop()
+            event.prevent_default()
+            if self._selected_index == 0:
+                self._exit_to_prompt()
+            else:
+                self._selected_index -= 1
+                self.refresh()
+        elif key == "escape":
+            event.stop()
+            event.prevent_default()
+            self._exit_to_prompt()
+        elif key == "enter":
+            event.stop()
+            event.prevent_default()
+            self._activate_selected()
+
+    def _activate_selected(self) -> None:
+        """Open the selected agent's viewer; the main row just returns to prompt."""
+        agents = self._agent_runs()
+        index = self._selected_index
+        if index <= 0 or index - 1 >= len(agents):
+            self._exit_to_prompt()
+            return
+        self._open_conversation(agents[index - 1])
+
+    # ---- Mouse ------------------------------------------------------------
+
+    def on_click(self, event: events.Click) -> None:
+        """Click a row to select it; agent rows open the viewer (pi/tau parity)."""
+        line = int(event.y)
+        if 0 <= line < len(self._row_runs):
+            run = self._row_runs[line]
+            if run is None:
+                self._exit_to_prompt()
+                return
+            # Reflect the click in the selection, then open.
+            agents = self._agent_runs()
+            if run in agents:
+                self._selected_index = agents.index(run) + 1
+            self._focused_nav = True
+            self._open_conversation(run)
+
+    # ---- Rendering --------------------------------------------------------
+
+    def render(self) -> Group:
+        """Render main + windowed agent rows, an overflow line, and a hint."""
+        agents = self._agent_runs()
+        self._row_runs = []
+        if not agents:
+            # No agents → render nothing (the strip is effectively hidden, pi parity).
+            return Group()
+
+        theme = self._theme
+        rows: list[Text] = []
+        sel = min(self._selected_index, self._roster_len() - 1)
+
+        # main row (roster index 0)
+        rows.append(self._render_row(0, sel, glyph="", label="main", detail="", run=None))
+        self._row_runs.append(None)
+
+        # Window agent rows so the selected one stays visible.
+        visible = min(STRIP_MAX_ROWS, len(agents))
+        sel_agent = max(0, sel - 1)
+        start = 0 if sel_agent < visible else sel_agent - visible + 1
+        window = agents[start : start + visible]
+        for offset, run in enumerate(window):
+            roster_index = start + offset + 1
+            rows.append(
+                self._render_row(
+                    roster_index,
+                    sel,
+                    glyph=self._glyph_for(run),
+                    label=run.agent_type,
+                    detail=run.description,
+                    run=run,
+                )
+            )
+            self._row_runs.append(run)
+
+        hidden = len(agents) - len(window)
+        if hidden > 0:
+            rows.append(
+                Text(
+                    f"    … {hidden} more — /agents",
+                    style=theme.muted_text,
+                    no_wrap=True,
+                    overflow="ellipsis",
+                )
+            )
+        hint = (
+            "↑ ↓ select · enter view · esc back"
+            if self._focused_nav
+            else "← agents"
+        )
+        rows.append(
+            Text(f"    {hint}", style=theme.muted_text, no_wrap=True, overflow="ellipsis")
+        )
+        return Group(*rows)
+
+    def _glyph_for(self, run: AgentRun) -> str:
+        if run.status == "running":
+            return _SPINNER_FRAMES[self._spinner_frame]
+        return STATUS_GLYPHS.get(run.status, "○")
+
+    def _render_row(
+        self,
+        index: int,
+        sel: int,
+        *,
+        glyph: str,
+        label: str,
+        detail: str,
+        run: AgentRun | None,
+    ) -> Text:
+        theme = self._theme
+        selected = index == sel
+        viewing = run is not None and run.agent_id == self.viewing_id
+        main_row = run is None and index == 0
+        row = Text(no_wrap=True, overflow="ellipsis")
+        row.append("❯ " if selected else "  ", style=theme.accent)
+        # A ● accent dot marks the row being viewed (and main when nothing is viewed).
+        if viewing or (main_row and self.viewing_id is None):
+            row.append("● ", style=theme.accent)
+        elif main_row:
+            row.append("○ ", style=theme.muted_text)
+        else:
+            glyph_style = (
+                theme.role_styles["error"].border
+                if run is not None and run.status == "error"
+                else theme.muted_text
+            )
+            row.append(f"{glyph} ", style=glyph_style)
+        active = viewing or (main_row and self.viewing_id is None)
+        label_style = theme.prompt_text if active else theme.muted_text
+        row.append(label, style=f"bold {label_style}" if selected else label_style)
+        if detail:
+            row.append(f"  {detail}", style=theme.muted_text)
+        if run is not None:
+            tokens = _lifetime_tokens(run)
+            stat = format_elapsed(run)
+            if run.has_usage and tokens:
+                stat += f" · {format_tokens(tokens)}"
+            row.append(f"  {stat}", style=theme.muted_text)
+        return row

--- a/src/tau_subagents/ui/strip.py
+++ b/src/tau_subagents/ui/strip.py
@@ -13,9 +13,11 @@ the prompt keeps focus throughout, and the controller's pre-dispatch key
 interceptor (:meth:`~tau_subagents.ui.controller.SubagentUiController._intercept_key`)
 owns the whole nav state machine. This widget only holds the visual nav state
 (``_focused_nav`` + ``_selected_index``) and exposes small mutators the
-controller drives — ``left``/``down`` at an empty prompt activate nav, arrows
-move the selection, ``enter`` opens an agent's viewer, ``esc`` / up-past-top
-deactivates. A mouse click still works with no focus (:meth:`on_click`).
+controller drives — ``left``/``down`` at an empty prompt activate nav (while a
+viewer is open, only ``left``: ``down`` scrolls the focused viewer), arrows
+move the selection, ``enter`` opens an agent's viewer (on the ``main`` row it
+closes any open viewer instead), ``esc`` / up-past-top deactivates. A mouse
+click still works with no focus (:meth:`on_click`).
 """
 
 from __future__ import annotations

--- a/src/tau_subagents/ui/strip.py
+++ b/src/tau_subagents/ui/strip.py
@@ -6,12 +6,14 @@ the rendering feel of tau core's old ``_render_agent_strip``. One row for
 runs and richer statuses (``steered``/``aborted``) render their own glyph
 directly (no down-mapping onto the old five-status vocabulary).
 
-Navigation follows the seam review's ruling: the extension's key interceptor
-(registered by :class:`~tau_subagents.ui.controller.SubagentUiController`) only
-ENTERS the strip — ``left``/``down`` at an empty prompt. Once the strip has
-Textual focus it owns its own nav via :meth:`on_key`; ``esc`` / up-past-top
-returns focus to the prompt. ``Enter`` (or a click) on an agent row opens the
-conversation viewer; the ``main`` row just returns to the prompt.
+Navigation follows pi's fleet-list model. The strip NEVER takes Textual focus:
+the prompt keeps focus throughout, and the controller's pre-dispatch key
+interceptor (:meth:`~tau_subagents.ui.controller.SubagentUiController._intercept_key`)
+owns the whole nav state machine. This widget only holds the visual nav state
+(``_focused_nav`` + ``_selected_index``) and exposes small mutators the
+controller drives — ``left``/``down`` at an empty prompt activate nav, arrows
+move the selection, ``enter`` opens an agent's viewer, ``esc`` / up-past-top
+deactivates. A mouse click still works with no focus (:meth:`on_click`).
 """
 
 from __future__ import annotations
@@ -79,10 +81,12 @@ def format_tokens(count: int) -> str:
 
 
 class AgentStripWidget(Static):
-    """Focusable below-prompt widget showing ``main`` + active subagent runs."""
+    """Below-prompt widget showing ``main`` + active subagent runs.
 
-    # A slot widget must be focusable so it can own keyboard nav once entered.
-    can_focus = True
+    Never takes focus: the controller's pre-dispatch key interceptor drives the
+    nav state held here (``_focused_nav`` / ``_selected_index``) via the mutators
+    below, so the prompt keeps focus throughout (pi's fleet-list model).
+    """
 
     DEFAULT_CSS = """
     AgentStripWidget {
@@ -119,14 +123,25 @@ class AgentStripWidget(Static):
         self.set_interval(SPINNER_INTERVAL, self._tick)
 
     def _tick(self) -> None:
-        """Advance the spinner and re-render (cheap; render reads live state)."""
+        """Advance the spinner and re-render (cheap; render reads live state).
+
+        Uses ``layout=True`` because a lingering run can expire between ticks,
+        shrinking the row count — a plain ``refresh()`` would leave a stale
+        height (the same class of bug as the mount-empty case).
+        """
         if self._agent_runs():
             self._spinner_frame = (self._spinner_frame + 1) % len(_SPINNER_FRAMES)
-        self.refresh()
+        self.refresh(layout=True)
 
     def refresh_roster(self) -> None:
-        """Re-render after the run list or a status changed (controller push)."""
-        self.refresh()
+        """Re-render after the run list or a status changed (controller push).
+
+        ``layout=True`` is mandatory: the strip mounts empty (height 0) and a
+        plain ``refresh()`` never re-measures, so a widget that gains its first
+        row would stay invisible. Any refresh that can change the row count
+        must relayout.
+        """
+        self.refresh(layout=True)
 
     # ---- Roster -----------------------------------------------------------
 
@@ -159,77 +174,57 @@ class AgentStripWidget(Static):
         """Total selectable rows: main + agents."""
         return 1 + len(self._agent_runs())
 
-    # ---- Entry / focus ----------------------------------------------------
+    # ---- Nav state (driven by the controller's key interceptor) -----------
 
-    def enter_strip(self) -> None:
-        """Take keyboard focus and start navigating from the top (main)."""
+    @property
+    def nav_active(self) -> bool:
+        """Whether arrow keys currently navigate the strip (vs. flow to prompt)."""
+        return self._focused_nav
+
+    @property
+    def selected_index(self) -> int:
+        """Current selection: 0 = ``main`` row, 1..N = agent rows."""
+        return self._selected_index
+
+    def activate_nav(self) -> None:
+        """Turn nav on and select the top (``main``) row."""
         self._focused_nav = True
         self._selected_index = 0
-        self.focus()
         self.refresh()
 
-    def _exit_to_prompt(self) -> None:
-        """Return focus to the prompt (host-owned ``#prompt``; noted coupling)."""
+    def deactivate_nav(self) -> None:
+        """Turn nav off and drop the highlight (prompt keeps focus regardless)."""
         self._focused_nav = False
         self._selected_index = 0
-        # The strip is a real Textual widget, so it reaches the host prompt by id.
-        # This is the extension→host coupling the component-seam experiment records.
-        try:
-            self.app.query_one("#prompt").focus()
-        except Exception:  # noqa: BLE001 - never let a focus miss crash nav
-            pass
         self.refresh()
 
-    def on_blur(self) -> None:
-        """Drop the nav highlight when focus leaves the strip by any route."""
-        self._focused_nav = False
+    def move_selection(self, delta: int) -> None:
+        """Move the selection by ``delta``, clamped to the roster (no wrap)."""
+        self._selected_index = max(
+            0, min(self._roster_len() - 1, self._selected_index + delta)
+        )
         self.refresh()
 
-    # ---- Keyboard nav (only while the strip holds focus) ------------------
-
-    def on_key(self, event: events.Key) -> None:
-        """Own navigation while focused; esc / up-past-top hands back to prompt."""
-        key = event.key
-        if key == "down":
-            event.stop()
-            event.prevent_default()
-            self._selected_index = min(self._roster_len() - 1, self._selected_index + 1)
-            self.refresh()
-        elif key == "up":
-            event.stop()
-            event.prevent_default()
-            if self._selected_index == 0:
-                self._exit_to_prompt()
-            else:
-                self._selected_index -= 1
-                self.refresh()
-        elif key == "escape":
-            event.stop()
-            event.prevent_default()
-            self._exit_to_prompt()
-        elif key == "enter":
-            event.stop()
-            event.prevent_default()
-            self._activate_selected()
-
-    def _activate_selected(self) -> None:
-        """Open the selected agent's viewer; the main row just returns to prompt."""
+    def selected_run(self) -> AgentRun | None:
+        """The run at the current selection, or ``None`` for the ``main`` row."""
         agents = self._agent_runs()
         index = self._selected_index
         if index <= 0 or index - 1 >= len(agents):
-            self._exit_to_prompt()
-            return
-        self._open_conversation(agents[index - 1])
+            return None
+        return agents[index - 1]
 
     # ---- Mouse ------------------------------------------------------------
 
     def on_click(self, event: events.Click) -> None:
-        """Click a row to select it; agent rows open the viewer (pi/tau parity)."""
+        """Click a row to open its viewer; needs no focus (pi/tau parity).
+
+        The ``main`` row just deactivates nav; an agent row selects and opens.
+        """
         line = int(event.y)
         if 0 <= line < len(self._row_runs):
             run = self._row_runs[line]
             if run is None:
-                self._exit_to_prompt()
+                self.deactivate_nav()
                 return
             # Reflect the click in the selection, then open.
             agents = self._agent_runs()

--- a/src/tau_subagents/ui/viewer.py
+++ b/src/tau_subagents/ui/viewer.py
@@ -152,8 +152,9 @@ class ConversationViewer(Vertical):
     def on_mount(self) -> None:
         """Focus the viewer, subscribe to run push events, and paint once."""
         # open_main_view leaves focus on the prompt; the viewer takes it so its
-        # own key handling (esc close, enter steer, x stop, scroll) works and it
-        # does not lean on the prompt-scoped interceptor.
+        # own key handling (esc close, enter steer, x stop, scroll) works
+        # without routing every command through the pre-dispatch interceptor
+        # (which stays live for strip nav while the viewer is open).
         self.focus()
         self._run.listeners.append(self._on_run_event)
         self._refresh_transcript()

--- a/src/tau_subagents/ui/viewer.py
+++ b/src/tau_subagents/ui/viewer.py
@@ -159,6 +159,15 @@ class ConversationViewer(Vertical):
         self._refresh_transcript()
         self._update_header()
 
+    @property
+    def composer_active(self) -> bool:
+        """Whether the steer composer is up (and owns the keyboard)."""
+        return self._composer is not None
+
+    def request_close(self) -> None:
+        """Close this view via its host handle (the strip-nav close path)."""
+        self._handle.close()
+
     def on_unmount(self) -> None:
         """Unsubscribe and let the controller forget this viewer."""
         try:

--- a/src/tau_subagents/ui/viewer.py
+++ b/src/tau_subagents/ui/viewer.py
@@ -1,0 +1,313 @@
+"""The conversation viewer: a main-area view of one subagent's live transcript.
+
+Ports pi-subagents' ``conversation-viewer.ts`` onto tau's component seam. Opened
+via ``context.ui.components.open_main_view`` (an in-tree, display-toggled main
+view — NOT a modal — so the fleet strip stays visible for peripheral awareness).
+
+Rendering deliberately REUSES tau core's own transcript internals rather than
+reinventing them: it feeds a :class:`tau_coding.tui.state.TuiState` (via
+``load_messages``) into a :class:`tau_coding.tui.widgets.TranscriptView` and
+calls ``update_from_state`` — exactly the ``TuiState`` + ``#agent-transcript-pane``
+mechanics tau core's ``_activate_source``/``_tick_agent_view`` used before this
+migration. Importing those host internals is the coupling this experiment
+measures; it is called out here because it is non-obvious.
+
+Live updates are push, not poll: the viewer subscribes to the run's listener
+registry on mount and unsubscribes on unmount (the analog of pi's
+``session.subscribe(() => tui.requestRender())``). Runs execute as asyncio tasks
+on the TUI event loop, so a listener calling widget methods runs on the UI
+thread and is safe (see the design's push-refresh invariant).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from rich.text import Text
+from textual.containers import Vertical
+from textual.widgets import Input, Static
+
+# Host-internal rendering reuse (the measured coupling): the viewer renders an
+# agent's conversation through the very same state + transcript widget the host
+# uses for the main chat, so message/tool/thinking formatting stays identical.
+from tau_coding.tui.state import TuiState
+from tau_coding.tui.widgets import TranscriptView
+
+from tau_agent.messages import UserMessage
+
+from ..agents_menu import run_snapshot_messages, steer_run, stop_run
+
+if TYPE_CHECKING:
+    from textual import events
+    from tau_coding.tui.config import TuiTheme
+
+    from ..extension import AgentRun, SubagentManager
+    from tau_coding.extensions import MainViewHandle
+
+ACTIVE_STATUSES = ("running", "queued")
+
+_STATUS_GLYPHS = {
+    "queued": "◌",
+    "running": "●",
+    "completed": "✓",
+    "steered": "↻",
+    "aborted": "⊘",
+    "error": "✗",
+    "cancelled": "∅",
+}
+
+
+def run_messages(run: AgentRun) -> tuple:
+    """Current conversation for a run (live session, else a terminal snapshot).
+
+    Mirrors the old ``run_transcript_source.messages()`` policy so the viewer
+    keeps showing a finished run's story after its session closes.
+    """
+    session = run.session
+    if session is not None:
+        try:
+            return tuple(session.messages)
+        except Exception:  # noqa: BLE001 - a closing session must not break the view
+            return ()
+    if run.status == "queued":
+        return (UserMessage(content=run.prompt),)
+    return run_snapshot_messages(run)
+
+
+class _SteerComposer(Input):
+    """Single-line steer composer; Esc cancels back to the viewer (pi parity)."""
+
+    def __init__(self, on_cancel: Callable[[], None]) -> None:
+        super().__init__(placeholder="Steer the agent…  Enter send · Esc cancel")
+        self._on_cancel = on_cancel
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "escape":
+            event.stop()
+            event.prevent_default()
+            self._on_cancel()
+
+
+class ConversationViewer(Vertical):
+    """Live transcript + steer composer + two-press stop for one subagent run."""
+
+    can_focus = True
+
+    DEFAULT_CSS = """
+    ConversationViewer {
+        height: 1fr;
+    }
+    ConversationViewer > #viewer-header {
+        height: auto;
+        padding: 0 0 1 0;
+    }
+    ConversationViewer > #viewer-transcript {
+        height: 1fr;
+    }
+    ConversationViewer > #viewer-composer {
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    """
+
+    def __init__(
+        self,
+        run: AgentRun,
+        handle: MainViewHandle,
+        manager: SubagentManager,
+        theme: TuiTheme,
+        *,
+        on_close: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__(id="subagents-conversation-viewer")
+        self._run = run
+        self._handle = handle
+        self._manager = manager
+        self._theme = theme
+        # Public so the controller can bind an identity-checked callback after
+        # construction (the viewer instance isn't available until then).
+        self.on_close = on_close
+        self._stop_armed = False
+        self._composer: _SteerComposer | None = None
+        self._transcript: TranscriptView | None = None
+        self._header: Static | None = None
+        # Last rendered header line, kept for observability/tests.
+        self._header_text: Text = Text()
+
+    # ---- Lifecycle --------------------------------------------------------
+
+    def compose(self):
+        """Header line, the reused transcript view, then the (empty) composer slot."""
+        self._header = Static("", id="viewer-header")
+        self._transcript = TranscriptView(
+            id="viewer-transcript",
+            min_width=1,
+            wrap=True,
+            highlight=True,
+            markup=False,
+        )
+        yield self._header
+        yield self._transcript
+
+    def on_mount(self) -> None:
+        """Focus the viewer, subscribe to run push events, and paint once."""
+        # open_main_view leaves focus on the prompt; the viewer takes it so its
+        # own key handling (esc close, enter steer, x stop, scroll) works and it
+        # does not lean on the prompt-scoped interceptor.
+        self.focus()
+        self._run.listeners.append(self._on_run_event)
+        self._refresh_transcript()
+        self._update_header()
+
+    def on_unmount(self) -> None:
+        """Unsubscribe and let the controller forget this viewer."""
+        try:
+            self._run.listeners.remove(self._on_run_event)
+        except ValueError:
+            pass
+        if self.on_close is not None:
+            self.on_close()
+
+    def _on_run_event(self) -> None:
+        """Run listener (on the UI loop): repaint transcript + header live."""
+        self._refresh_transcript()
+        self._update_header()
+
+    def on_external_change(self) -> None:
+        """Controller push (roster/status change) — repaint header + transcript."""
+        self._refresh_transcript()
+        self._update_header()
+
+    # ---- Steer / stop capability -----------------------------------------
+
+    def _can_steer(self) -> bool:
+        return self._run.status in ACTIVE_STATUSES
+
+    def _is_stoppable(self) -> bool:
+        return self._run.status in ACTIVE_STATUSES
+
+    # ---- Keyboard ---------------------------------------------------------
+
+    def on_key(self, event: events.Key) -> None:
+        """Viewer commands while focused (the composer owns keys while it is up)."""
+        if self._composer is not None:
+            return
+        key = event.key
+        if key in ("escape", "q"):
+            event.stop()
+            event.prevent_default()
+            self._handle.close()
+            return
+        if key == "enter":
+            event.stop()
+            event.prevent_default()
+            if self._can_steer():
+                self._stop_armed = False
+                self._open_composer()
+            return
+        if key == "x":
+            event.stop()
+            event.prevent_default()
+            if self._is_stoppable():
+                if self._stop_armed:
+                    self._stop_armed = False
+                    stop_run(self._run)
+                else:
+                    self._stop_armed = True
+                self._update_header()
+            return
+        # Any other key disarms a pending stop (pi's guard), then scrolls.
+        if self._stop_armed:
+            self._stop_armed = False
+            self._update_header()
+        transcript = self._transcript
+        if transcript is None:
+            return
+        if key in ("up", "k"):
+            transcript.scroll_up()
+            event.stop()
+        elif key in ("down", "j"):
+            transcript.scroll_down()
+            event.stop()
+        elif key == "pageup":
+            transcript.scroll_page_up()
+            event.stop()
+        elif key == "pagedown":
+            transcript.scroll_page_down()
+            event.stop()
+        elif key == "home":
+            transcript.scroll_home()
+            event.stop()
+        elif key == "end":
+            transcript.scroll_end()
+            event.stop()
+
+    # ---- Steer composer ---------------------------------------------------
+
+    def _open_composer(self) -> None:
+        composer = _SteerComposer(on_cancel=self._close_composer)
+        self._composer = composer
+        self.mount(composer)
+        composer.focus()
+
+    def _close_composer(self) -> None:
+        composer = self._composer
+        self._composer = None
+        if composer is not None:
+            composer.remove()
+        self.focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Enter in the composer sends the steering message and closes the composer."""
+        if self._composer is None or event.input is not self._composer:
+            return
+        event.stop()
+        message = event.value.strip()
+        self._close_composer()
+        if message:
+            steer_run(self._run, message)
+
+    # ---- Rendering --------------------------------------------------------
+
+    def _refresh_transcript(self) -> None:
+        transcript = self._transcript
+        if transcript is None:
+            return
+        state = TuiState()
+        state.load_messages(run_messages(self._run))
+        transcript.update_from_state(state, theme=self._theme)
+
+    def _update_header(self) -> None:
+        header = self._header
+        if header is None:
+            return
+        run = self._run
+        theme = self._theme
+        glyph = _STATUS_GLYPHS.get(run.status, "○")
+        glyph_style = (
+            theme.role_styles["error"].border
+            if run.status == "error"
+            else theme.accent
+            if run.status in ACTIVE_STATUSES
+            else theme.muted_text
+        )
+        line = Text(no_wrap=True, overflow="ellipsis")
+        line.append(f"{glyph} ", style=glyph_style)
+        line.append(run.agent_type, style=f"bold {theme.prompt_text}")
+        line.append(f" [{run.status}]", style=theme.muted_text)
+        if run.description:
+            line.append(f"  {run.description}", style=theme.muted_text)
+        # Right-hand action hints, mirroring pi's footer affordances.
+        hints: list[str] = []
+        if self._can_steer():
+            hints.append("Enter steer")
+        if self._is_stoppable():
+            hints.append("x again to STOP" if self._stop_armed else "x stop")
+        hints.append("Esc close")
+        hint_style = (
+            theme.role_styles["error"].border if self._stop_armed else theme.muted_text
+        )
+        line.append("   ")
+        line.append(" · ".join(hints), style=hint_style)
+        self._header_text = line
+        header.update(line)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1572,7 +1572,7 @@ def test_notification_renderer_formats_details(tmp_path: Path) -> None:
     collapsed = render(view, SimpleNamespace(expanded=False))
     assert "[green]✓[/green]" in collapsed
     assert "[bold]deploy watch[/bold]" in collapsed
-    assert "3/10 turns" in collapsed
+    assert "3 turns (max 10)" in collapsed
     assert "1.5k tokens" in collapsed
     assert "2.3s" in collapsed
     # A multi-line preview collapses to its first line plus an ellipsis, and
@@ -1631,7 +1631,7 @@ def test_agent_result_renderer_formats_card(tmp_path: Path) -> None:
     collapsed = render(SimpleNamespace(details=details), expanded=False)
     # Compact card: the description already sits on the invocation line above,
     # so the card starts with the status and stats.
-    assert collapsed.startswith("[green]✓[/green] [dim]completed · 3/10 turns")
+    assert collapsed.startswith("[green]✓[/green] [dim]completed · 3 turns (max 10)")
     assert "deploy watch" not in collapsed
     assert "1.5k tokens" in collapsed
     assert "⎿  line one…" in collapsed

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1701,6 +1701,37 @@ def test_agent_result_renderer_formats_card(tmp_path: Path) -> None:
     assert render(SimpleNamespace(details=None), expanded=False) is None
 
 
+async def test_hard_cancelled_tool_call_stops_the_ticker(tmp_path: Path) -> None:
+    # Tau can hard-cancel the tool coroutine mid-wait (consumer teardown). The
+    # run task keeps going; the ticker callback must be cleared so the still-
+    # running child does not keep ticking into an orphaned callback.
+    runtime = _load_runtime(tmp_path)
+    runtime.bind(RecordingSession(tmp_path))
+    release = asyncio.Event()
+    _patch_provider_factory(_extension_module(), BlockingProvider(release, "done"))
+
+    agent_tool = _agent_tool(runtime)
+    updates: list[str] = []
+    task = asyncio.create_task(
+        agent_tool.execute(
+            {"prompt": "go", "description": "d"},
+            on_update=lambda message, data=None: updates.append(message),
+        )
+    )
+    await asyncio.sleep(0.1)  # let the executor enter its wait loop
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    updates.clear()
+    release.set()
+    # Pump the loop so the (still-running) child finishes its events; a leaked
+    # callback would append ticker lines here.
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+    assert updates == []
+
+
 async def test_foreground_cancel_returns_cancelled_card_details(tmp_path: Path) -> None:
     # Esc-cancel stays in the card family: the result carries details so the
     # row renders "✗ cancelled" instead of falling back to the generic block.

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1490,10 +1490,11 @@ async def test_real_usage_accumulates_and_surfaces(tmp_path: Path) -> None:
     assert "<usage><total_tokens>60</total_tokens><tool_uses>0</tool_uses>" in note
 
 
-async def test_foreground_run_emits_no_progress_updates(tmp_path: Path) -> None:
-    # The spinner on the pending tool row (tau core) is the live activity
-    # signal now; per-event "agent-n: turn n" updates were deliberately
-    # removed as transcript noise.
+async def test_foreground_run_emits_live_stats_ticker(tmp_path: Path) -> None:
+    # The ticker is one stable, cumulative line in the completion card's stats
+    # vocabulary — NOT the per-event "agent-n: turn n" activity echo that was
+    # dropped as transcript noise (d0d5ac8). It only fires when a stat changes,
+    # so the running row morphs into the finished card.
     runtime = _load_runtime(tmp_path)
     runtime.bind(RecordingSession(tmp_path))
     module = _extension_module()
@@ -1511,7 +1512,12 @@ async def test_foreground_run_emits_no_progress_updates(tmp_path: Path) -> None:
     )
 
     assert result.ok is True
-    assert updates == []
+    assert updates, "foreground run should stream the live stats ticker"
+    assert "1 tool use" in updates
+    assert updates[-1] == "2 turns · 1 tool use"
+    # Cumulative and deduplicated: every emission differs from the previous.
+    assert len(updates) == len(set(updates))
+    assert all("agent-" not in message for message in updates)
 
 
 async def test_inherit_context_prepends_parent_conversation(tmp_path: Path) -> None:
@@ -1604,6 +1610,113 @@ def test_notification_renderer_formats_details(tmp_path: Path) -> None:
     assert "second run" in both
 
     assert render(SimpleNamespace(details=None), SimpleNamespace(expanded=False)) is None
+
+
+def test_agent_result_renderer_formats_card(tmp_path: Path) -> None:
+    _load_runtime(tmp_path)
+    render = _submodule("notification_render").render_agent_result
+    details = {
+        "description": "deploy watch",
+        "status": "completed",
+        "turn_count": 3,
+        "max_turns": 10,
+        "tool_uses": 2,
+        "total_tokens": 1500,
+        "duration_ms": 2300,
+        "output_file": "/tmp/t.jsonl",
+        "error": None,
+        "result_preview": "line one\nline two",
+    }
+
+    collapsed = render(SimpleNamespace(details=details), expanded=False)
+    # Compact card: the description already sits on the invocation line above,
+    # so the card starts with the status and stats.
+    assert collapsed.startswith("[green]✓[/green] [dim]completed · 3/10 turns")
+    assert "deploy watch" not in collapsed
+    assert "1.5k tokens" in collapsed
+    assert "⎿  line one…" in collapsed
+    assert "transcript:" not in collapsed
+
+    expanded = render(SimpleNamespace(details=details), expanded=True)
+    assert "line two" in expanded
+    assert "transcript: /tmp/t.jsonl" in expanded
+
+    # Failure previews render red (the run's error text, not routine output).
+    error = render(
+        SimpleNamespace(details={**details, "status": "error", "result_preview": "boom"}),
+        expanded=False,
+    )
+    assert error.startswith("[red]✗[/red] [dim]error")
+    assert "[red]⎿  boom[/red]" in error
+
+    # A steered finish gets the cautionary yellow ✓.
+    steered = render(
+        SimpleNamespace(details={**details, "status": "steered"}), expanded=False
+    )
+    assert steered.startswith("[yellow]✓[/yellow] [dim]completed (steered)")
+
+    # Expanded views past the line cap say what was hidden.
+    tall = SimpleNamespace(
+        details={**details, "result_preview": "\n".join(f"l{i}" for i in range(35))}
+    )
+    tall_expanded = render(tall, expanded=True)
+    assert "… 5 more lines — get_subagent_result for full output" in tall_expanded
+
+    # Result text with Rich markup renders literally (escaping round-trip).
+    from rich.text import Text
+
+    marked = render(
+        SimpleNamespace(
+            details={**details, "result_preview": "found [red]3[/red] in [module]"}
+        ),
+        expanded=False,
+    )
+    assert "found [red]3[/red] in [module]" in Text.from_markup(marked).plain
+
+    spawned = render(
+        SimpleNamespace(details={"status": "background", "agent_id": "agent-1"}),
+        expanded=False,
+    )
+    assert spawned == "  [dim]⎿  Running in background (agent-1)[/dim]"
+    queued = render(
+        SimpleNamespace(
+            details={"status": "background", "agent_id": "agent-2", "queued": True}
+        ),
+        expanded=False,
+    )
+    assert "Queued in background (agent-2)" in queued
+    spawned_expanded = render(
+        SimpleNamespace(
+            details={
+                "status": "background",
+                "agent_id": "agent-1",
+                "output_file": "/tmp/t.jsonl",
+            }
+        ),
+        expanded=True,
+    )
+    assert "transcript: /tmp/t.jsonl" in spawned_expanded
+
+    # No details (e.g. argument-validation failures) → generic fallback.
+    assert render(SimpleNamespace(details=None), expanded=False) is None
+
+
+async def test_foreground_cancel_returns_cancelled_card_details(tmp_path: Path) -> None:
+    # Esc-cancel stays in the card family: the result carries details so the
+    # row renders "✗ cancelled" instead of falling back to the generic block.
+    runtime = _load_runtime(tmp_path)
+    runtime.bind(RecordingSession(tmp_path))
+    release = asyncio.Event()
+    _patch_provider_factory(_extension_module(), BlockingProvider(release, "never"))
+
+    agent_tool = _agent_tool(runtime)
+    signal = SimpleNamespace(is_cancelled=lambda: True)
+    result = await agent_tool.execute({"prompt": "go", "description": "d"}, signal=signal)
+
+    assert result.ok is False
+    assert "Subagent cancelled" in result.content
+    assert result.details is not None
+    assert result.details["status"] == "cancelled"
 
 
 async def test_notification_delivered_as_custom_message(tmp_path: Path) -> None:
@@ -1962,6 +2075,12 @@ async def test_foreground_run_returns_result(tmp_path: Path) -> None:
     assert result.ok is True
     assert "Subagent report: all good." in result.content
     assert "agent-1 [completed]" in result.content
+    # The result carries the completion-card details for the tool's
+    # render_result hook (the foreground twin of the background notification).
+    assert agent_tool.render_result is not None
+    assert result.details is not None
+    assert result.details["status"] == "completed"
+    assert result.details["result_preview"] == "Subagent report: all good."
 
 
 async def test_background_run_delivers_notification(tmp_path: Path) -> None:
@@ -1980,6 +2099,11 @@ async def test_background_run_delivers_notification(tmp_path: Path) -> None:
     )
     assert spawn_result.ok is True
     assert "agent-1" in spawn_result.content
+    assert spawn_result.details is not None
+    assert spawn_result.details["status"] == "background"
+    assert spawn_result.details["agent_id"] == "agent-1"
+    assert spawn_result.details["queued"] is False
+    assert str(spawn_result.details["output_file"]).endswith("agent-1.jsonl")
 
     for _ in range(200):
         if session.followed_up:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1568,12 +1568,30 @@ def test_notification_renderer_formats_details(tmp_path: Path) -> None:
     assert "[bold]deploy watch[/bold]" in collapsed
     assert "3/10 turns" in collapsed
     assert "1.5k tokens" in collapsed
-    assert "⎿  line one" in collapsed
+    assert "2.3s" in collapsed
+    # A multi-line preview collapses to its first line plus an ellipsis, and
+    # the transcript path stays out of the collapsed card.
+    assert "⎿  line one…" in collapsed
     assert "line two" not in collapsed
-    assert "transcript: /tmp/t.jsonl" in collapsed
+    assert "transcript:" not in collapsed
 
     expanded = render(view, SimpleNamespace(expanded=True))
     assert "line two" in expanded
+    assert "transcript: /tmp/t.jsonl" in expanded
+
+    # Long first lines cut at a word boundary, never mid-word.
+    long_view = SimpleNamespace(
+        details={**details, "result_preview": ("word " * 40).strip()}
+    )
+    long_collapsed = render(long_view, SimpleNamespace(expanded=False))
+    preview_line = next(
+        line for line in long_collapsed.split("\n") if "⎿" in line
+    )
+    assert preview_line.rstrip("[/dim]").endswith("word…")
+
+    # Durations of a minute or more switch to the elapsed style.
+    slow_view = SimpleNamespace(details={**details, "duration_ms": 83_200})
+    assert "1m 23s" in render(slow_view, SimpleNamespace(expanded=False))
 
     error_view = SimpleNamespace(details={**details, "status": "error"})
     assert "[red]✗[/red]" in render(error_view, SimpleNamespace(expanded=False))

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1602,6 +1602,11 @@ def test_notification_renderer_formats_details(tmp_path: Path) -> None:
     error_view = SimpleNamespace(details={**details, "status": "error"})
     assert "[red]✗[/red]" in render(error_view, SimpleNamespace(expanded=False))
 
+    cancelled_view = SimpleNamespace(details={**details, "status": "cancelled"})
+    cancelled_card = render(cancelled_view, SimpleNamespace(expanded=False))
+    assert "[dim]∅[/dim]" in cancelled_card
+    assert "[red]" not in cancelled_card
+
     grouped = SimpleNamespace(
         details={**details, "others": [{**details, "description": "second run"}]}
     )
@@ -1655,6 +1660,13 @@ def test_agent_result_renderer_formats_card(tmp_path: Path) -> None:
     )
     assert steered.startswith("[yellow]✓[/yellow] [dim]completed (steered)")
 
+    # User-initiated stops render neutral-dim (pi's ■ Stopped), not red.
+    cancelled = render(
+        SimpleNamespace(details={**details, "status": "cancelled"}), expanded=False
+    )
+    assert cancelled.startswith("[dim]∅[/dim] [dim]cancelled")
+    assert "[red]" not in cancelled
+
     # Expanded views past the line cap say what was hidden.
     tall = SimpleNamespace(
         details={**details, "result_preview": "\n".join(f"l{i}" for i in range(35))}
@@ -1701,10 +1713,11 @@ def test_agent_result_renderer_formats_card(tmp_path: Path) -> None:
     assert render(SimpleNamespace(details=None), expanded=False) is None
 
 
-async def test_hard_cancelled_tool_call_stops_the_ticker(tmp_path: Path) -> None:
-    # Tau can hard-cancel the tool coroutine mid-wait (consumer teardown). The
-    # run task keeps going; the ticker callback must be cleared so the still-
-    # running child does not keep ticking into an orphaned callback.
+async def test_hard_cancel_cascades_to_the_child(tmp_path: Path) -> None:
+    # Esc in the TUI hard-cancels the tool coroutine (consumer teardown). The
+    # cascade must take the child down too — no zombie run burning tokens with
+    # its result silently dropped — settle the record as cancelled, and clear
+    # the ticker callback.
     runtime = _load_runtime(tmp_path)
     runtime.bind(RecordingSession(tmp_path))
     release = asyncio.Event()
@@ -1723,13 +1736,22 @@ async def test_hard_cancelled_tool_call_stops_the_ticker(tmp_path: Path) -> None
     with pytest.raises(asyncio.CancelledError):
         await task
 
+    # The child is gone and the record settled: /agents and get_subagent_result
+    # agree the run is over.
+    get_result = next(
+        tool for tool in runtime.extension_tools if tool.name == "get_subagent_result"
+    )
+    probed = await get_result.execute({"agent_id": "agent-1"})
+    assert "[cancelled]" in probed.content
+
     updates.clear()
     release.set()
-    # Pump the loop so the (still-running) child finishes its events; a leaked
-    # callback would append ticker lines here.
+    # Pump the loop; a surviving child (or leaked callback) would tick here.
     for _ in range(20):
         await asyncio.sleep(0.01)
     assert updates == []
+    probed_again = await get_result.execute({"agent_id": "agent-1"})
+    assert "[cancelled]" in probed_again.content
 
 
 async def test_foreground_cancel_returns_cancelled_card_details(tmp_path: Path) -> None:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1722,93 +1722,58 @@ async def test_agents_menu_shows_finished_result(tmp_path: Path) -> None:
     assert menu.supports_menu(None) is False
 
 
-def test_run_transcript_source_maps_live_and_terminal_runs() -> None:
-    extension = _extension_module()
-
-    live = _menu_run(extension, status="running")
-    steered: list[str] = []
-    live.session = SimpleNamespace(
-        messages=[UserMessage(content="child prompt")],
-        queue_steering_message=steered.append,
-    )
-    live.revision = 7
-    source = extension.run_transcript_source(live)
-    assert (source.id, source.label, source.detail) == ("agent-1", "general", "task")
-    assert source.status == "running"
-    assert source.revision == 7
-    assert source.messages() == (UserMessage(content="child prompt"),)
-    source.steer("focus on tests")
-    assert steered == ["focus on tests"]
-
-    done = _menu_run(extension, status="completed", result_text="Final report")
-    source = extension.run_transcript_source(done)
-    assert source.status == "done"
-    assert source.steer is None
-    snapshot = source.messages()
-    assert snapshot is not None
-    assert snapshot[0].content == "p"
-    assert snapshot[1].content == "Final report"
-
-    queued = _menu_run(extension, status="queued")
-    source = extension.run_transcript_source(queued)
-    assert source.status == "queued"
-    assert source.messages() == (UserMessage(content="p"),)
-    source.steer("get ahead of it")
-    assert queued.pending_steers == ["get ahead of it"]
-
-    aborted = _menu_run(extension, status="aborted")
-    assert extension.run_transcript_source(aborted).status == "cancelled"
-
-
-async def test_transcript_sources_published_and_signalled(tmp_path: Path) -> None:
-    runtime = _load_runtime(tmp_path)
-    session = RecordingSession(tmp_path)
-    runtime.bind(session)
-    fired: list[int] = []
-    runtime.set_transcript_sources_changed_callback(lambda: fired.append(1))
-    _patch_provider_factory(_extension_module(), FakeProvider([_text_stream("done")]))
-
-    agent_tool = _agent_tool(runtime)
-    await agent_tool.execute({"prompt": "task", "description": "map the code"})
-
-    assert fired  # spawn + completion pushed the sources-changed signal
-    sources = runtime.transcript_sources()
-    assert len(sources) == 1
-    assert sources[0].id == "agent-1"
-    assert sources[0].status == "done"
-    assert sources[0].detail == "map the code"
-    messages = sources[0].messages()
-    assert messages is not None and len(messages) >= 2
-
-
-async def test_agents_menu_prefers_in_place_view(tmp_path: Path) -> None:
+async def test_agents_menu_opens_conversation_via_component_seam(tmp_path: Path) -> None:
+    # The transcript-source view_transcript seam is gone: the menu now opens the
+    # extension's own viewer through the component controller. On success the
+    # whole menu unwinds ("exit") so the user lands in the view.
     _load_runtime(tmp_path)
     menu = _submodule("agents_menu")
     run = _menu_run(_extension_module(), status="running")
     manager = SimpleNamespace(runs={"agent-1": run}, definitions=dict)
 
-    class InPlaceUi(ScriptedUi):
-        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
-            super().__init__(*args, **kwargs)
-            self.viewed: list[str] = []
+    opened: list[str] = []
 
-        async def view_transcript(self, source_id: str) -> bool:
-            self.viewed.append(source_id)
+    class FakeController:
+        def open_conversation(self, run) -> bool:  # noqa: ANN001
+            opened.append(run.agent_id)
             return True
 
-    ui = InPlaceUi(
+    ui = ScriptedUi(
         selects=[
             lambda options: options[0],  # top: Running agents (…)
-            lambda options: options[0],  # the run → switches the main view
+            lambda options: options[0],  # the run → opens the viewer
         ],
     )
 
-    await menu.show_agents_menu(manager, ui)
+    await menu.show_agents_menu(manager, ui, controller=FakeController())
 
-    # The whole menu unwound so the user lands in the in-place view; the
-    # action submenu never opened.
-    assert ui.viewed == ["agent-1"]
+    assert opened == ["agent-1"]
+    # The action submenu never opened (only the two selects above).
     assert len(ui.select_calls) == 2
+
+
+async def test_agents_menu_degrades_to_actions_without_controller(tmp_path: Path) -> None:
+    # A component-less host (controller=None) falls straight to the action
+    # submenu, exactly as the old view_transcript-missing branch did.
+    _load_runtime(tmp_path)
+    menu = _submodule("agents_menu")
+    run = _menu_run(_extension_module(), status="running")
+    manager = SimpleNamespace(runs={"agent-1": run}, definitions=dict)
+
+    ui = ScriptedUi(
+        selects=[
+            lambda options: options[0],  # top: Running agents (…)
+            lambda options: options[0],  # the run → no controller → actions
+            "Back",  # action submenu
+            None,  # leave run list
+            None,  # leave top menu
+        ],
+    )
+
+    await menu.show_agents_menu(manager, ui, controller=None)
+
+    # The action submenu opened (its title names the run).
+    assert any(title.startswith("agent-1 [running]") for title, _ in ui.select_calls)
 
 
 def test_render_call_lines() -> None:

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -15,6 +15,7 @@ It is the experiment's proof of life: it exercises the session_start ordering
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,6 +23,8 @@ import pytest
 from textual.containers import Container
 
 from tau_agent import QueueUpdateEvent, UserMessage
+from tau_agent.messages import AssistantMessage
+from tau_ai import ProviderResponseEndEvent, ProviderResponseStartEvent
 from tau_coding.session import ModelChoice, TerminalCommandResult
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
@@ -33,7 +36,12 @@ from tau_subagents.ui.strip import AgentStripWidget
 from tau_subagents.ui.viewer import ConversationViewer
 
 # Sibling test modules (pytest prepend import mode puts tests/ on sys.path).
-from test_extension import _load_runtime  # noqa: E402
+from test_extension import (  # noqa: E402
+    _agent_tool,
+    _extension_module,
+    _load_runtime,
+    _patch_provider_factory,
+)
 from test_ui import _run, _strip_text  # noqa: E402
 
 pytestmark = pytest.mark.anyio
@@ -210,3 +218,113 @@ async def test_real_app_mounts_extension_strip_and_viewer(tmp_path) -> None:  # 
         assert app.query_one("#main-slot", Container).display is False
         # Focus returned to the host prompt.
         assert app.query_one("#prompt", PromptInput).has_focus
+
+
+class _GatedProvider:
+    """A provider whose single response stalls on an event, keeping the run alive.
+
+    Modeled on ``test_extension.BlockingProvider``: the spawned run stays
+    ``running`` (so the strip stays populated with a live row) until ``release``
+    is set, which lets the E2E observe the strip and drive keyboard nav without
+    racing the run to completion.
+    """
+
+    def __init__(self, release: asyncio.Event) -> None:
+        self._release = release
+
+    def stream_response(self, *, model, system, messages, tools, signal=None):  # noqa: ANN001, ANN202
+        async def iterator():  # noqa: ANN202
+            await self._release.wait()
+            yield ProviderResponseStartEvent(model="fake")
+            yield ProviderResponseEndEvent(message=AssistantMessage(content="done"))
+
+        return iterator()
+
+
+async def _wait_until(pilot, condition, *, tries: int = 200) -> None:  # noqa: ANN001
+    """Pump the event loop until ``condition()`` holds (or we give up)."""
+    for _ in range(tries):
+        if condition():
+            return
+        await pilot.pause()
+
+
+async def test_real_spawn_lights_strip_and_keyboard_opens_viewer(tmp_path) -> None:  # noqa: ANN001
+    """End-to-end proof: a real background spawn lights the strip (with non-zero
+    height), and REAL key presses drive the fleet-list nav — ``left`` activates,
+    ``down``+``enter`` open the viewer, ``escape`` closes it — all through the
+    pre-dispatch key interceptor, with the prompt keeping focus throughout.
+    """
+    app, session = _make_app(tmp_path)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+
+        release = asyncio.Event()
+        _patch_provider_factory(_extension_module(), _GatedProvider(release))
+        agent_tool = _agent_tool(session.extension_runtime)
+
+        # Spawn through the REAL agent tool, in the background so it returns at once
+        # while the run keeps executing on the TUI event loop.
+        result = await agent_tool.execute(
+            {
+                "prompt": "look around",
+                "description": "survey the repo",
+                "subagent_type": "explore",
+                "run_in_background": True,
+            }
+        )
+        assert result.ok, result.content
+
+        slot = app.query_one("#below-prompt-slot", Container)
+        strip = slot.query(AgentStripWidget).first()
+
+        # A. The real spawn path lit up the strip with no manual signal.
+        await _wait_until(pilot, strip.has_agents)
+        assert strip.has_agents(), "spawn did not populate the strip"
+        assert "explore" in _strip_text(strip)
+
+        # A'. Geometry regression: the strip must actually occupy visible height
+        # (the invisible zero-height bug — refresh() without layout=True).
+        await _wait_until(pilot, lambda: strip.region.height > 0)
+        assert strip.region.height > 0, "strip mounted but stayed zero-height"
+        assert strip.display is True
+        # And it is genuinely on screen (the compositor is painting it).
+        assert strip in app.screen._compositor.visible_widgets
+
+        # B. REAL keyboard: left at the empty prompt activates nav (no focus steal).
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.focus()
+        await pilot.pause()
+        assert prompt.has_focus
+        await pilot.press("left")
+        await pilot.pause()
+        assert strip.nav_active, "left at empty prompt did not activate strip nav"
+        assert prompt.has_focus, "strip stole focus from the prompt"
+        assert strip.selected_index == 0  # highlights the main row first
+
+        # C. down moves onto the agent row; enter opens the real viewer in #main-slot.
+        await pilot.press("down")
+        await pilot.pause()
+        assert strip.selected_index == 1
+        await pilot.press("enter")
+        await pilot.pause()
+        main_slot = app.query_one("#main-slot", Container)
+        viewers = main_slot.query(ConversationViewer)
+        assert viewers, "enter on the agent row did not open the viewer"
+        assert app.query_one("#transcript", TranscriptView).display is False
+        assert main_slot.display is True
+        # Opening the viewer reset the strip's nav state.
+        assert strip.nav_active is False
+
+        # D. escape (with the viewer focused) closes it and restores the transcript.
+        assert viewers.first().has_focus
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not main_slot.query(ConversationViewer)
+        assert app.query_one("#transcript", TranscriptView).display is True
+        assert main_slot.display is False
+
+        # Let the stalled run finish so teardown is clean.
+        release.set()
+        await pilot.pause()

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -22,15 +22,20 @@ from types import SimpleNamespace
 import pytest
 from textual.containers import Container
 
-from tau_agent import QueueUpdateEvent
+from tau_agent import (
+    QueueUpdateEvent,
+    ToolCall,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+)
 from tau_agent.messages import AssistantMessage
-from tau_ai import ProviderResponseEndEvent, ProviderResponseStartEvent
+from tau_ai import FakeProvider, ProviderResponseEndEvent, ProviderResponseStartEvent
 from tau_coding.session import ModelChoice, TerminalCommandResult
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tools import create_coding_tools
 from tau_coding.tui.app import PromptInput, TauTuiApp
-from tau_coding.tui.widgets import TranscriptView
+from tau_coding.tui.widgets import TranscriptMessageWidget, TranscriptView
 
 from tau_subagents.ui.strip import AgentStripWidget
 from tau_subagents.ui.viewer import ConversationViewer
@@ -41,6 +46,7 @@ from test_extension import (  # noqa: E402
     _extension_module,
     _load_runtime,
     _patch_provider_factory,
+    _text_stream,
 )
 from test_ui import _run, _strip_text  # noqa: E402
 
@@ -523,3 +529,54 @@ async def test_journey_switch_viewers_then_back_to_main(tmp_path) -> None:  # no
 
         release.set()
         await pilot.pause()
+
+
+async def test_foreground_result_renders_completion_card(tmp_path) -> None:  # noqa: ANN001
+    """End-to-end proof of the render_result seam: a REAL foreground agent run's
+    result, streamed through the REAL app, renders the completion card on the
+    tool row (invocation line + ✓ stats + ⎿ preview) instead of the bare
+    invocation the row used to collapse back to.
+    """
+    app, session = _make_app(tmp_path)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+
+        _patch_provider_factory(
+            _extension_module(),
+            FakeProvider([_text_stream("Subagent report: all good.")]),
+        )
+        agent_tool = _agent_tool(session.extension_runtime)
+        result = await agent_tool.execute(
+            {"prompt": "go", "description": "survey the repo"}
+        )
+        # In production the loop stamps the id; the tool returns it blank.
+        result = result.model_copy(update={"tool_call_id": "call-1"})
+
+        async def stream(event) -> None:  # noqa: ANN001
+            app.adapter.apply(event)
+            await app._apply_streaming_transcript_event(event)
+
+        await stream(
+            ToolExecutionStartEvent(
+                tool_call=ToolCall(
+                    id="call-1",
+                    name="agent",
+                    arguments={"prompt": "go", "description": "survey the repo"},
+                )
+            )
+        )
+        await stream(ToolExecutionEndEvent(result=result))
+        await pilot.pause()
+
+        widget = next(
+            w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"
+        )
+        text = widget.selection_text
+        # The render_call invocation line stays…
+        assert "▸ general agent · survey the repo" in text
+        # …with the compact completion card beneath it.
+        assert "✓ completed" in text
+        assert "⎿  Subagent report: all good." in text
+        # The raw tool-result body stays out of the collapsed row.
+        assert "agent-1 [completed]" not in text

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 import pytest
 from textual.containers import Container
 
-from tau_agent import QueueUpdateEvent, UserMessage
+from tau_agent import QueueUpdateEvent
 from tau_agent.messages import AssistantMessage
 from tau_ai import ProviderResponseEndEvent, ProviderResponseStartEvent
 from tau_coding.session import ModelChoice, TerminalCommandResult

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -328,3 +328,198 @@ async def test_real_spawn_lights_strip_and_keyboard_opens_viewer(tmp_path) -> No
         # Let the stalled run finish so teardown is clean.
         release.set()
         await pilot.pause()
+
+
+async def _settle(pilot) -> None:  # noqa: ANN001
+    """Pump through an async component swap (deferred remove -> mount)."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+        await pilot.pause()
+
+
+def _seed_run(strip, agent_id: str, *, agent_type: str, description: str):  # noqa: ANN001, ANN202
+    run = _run(
+        agent_id,
+        agent_type=agent_type,
+        description=description,
+        status="running",
+        session=SimpleNamespace(messages=()),
+    )
+    strip._manager.runs[agent_id] = run
+    return run
+
+
+# --- Regression: the deferred-remove DuplicateIds race (bug fix 2) -----------
+# These capture the two user-reported crashes the crash spike diagnosed:
+# opening a second agent's viewer while one is open, and a same-tick extension
+# teardown+reinstall (session rebind). With the host sequencing swaps after
+# removals drain, both land exactly one widget with zero component failures.
+
+
+async def test_rapid_viewer_switch_mounts_exactly_one_viewer(tmp_path) -> None:  # noqa: ANN001
+    """Opening a second viewer the same tick a first opens -> one viewer, no crash."""
+    app, _session = _make_app(tmp_path)
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        strip = app.query_one("#below-prompt-slot", Container).query(AgentStripWidget).first()
+        controller = strip._open_conversation.__self__  # the SubagentUiController
+        run_a = _seed_run(strip, "agent-1", agent_type="explore", description="A")
+        run_b = _seed_run(strip, "agent-2", agent_type="general", description="B")
+        strip._manager.sources_changed()
+        await pilot.pause()
+
+        # Same tick: open A, then immediately B (the reported second-viewer action).
+        assert controller.open_conversation(run_a) is True
+        assert controller.open_conversation(run_b) is True
+        await _settle(pilot)
+
+        viewers = app.query(ConversationViewer)
+        assert len(viewers) == 1, "rapid switch left more than one viewer mounted"
+        assert viewers.first()._run.agent_id == "agent-2"  # last-writer wins
+        assert app.query_one("#transcript", TranscriptView).display is False
+        assert app._extension_component_failures_reported == set()
+
+
+async def test_rapid_viewer_switch_a_b_c(tmp_path) -> None:  # noqa: ANN001
+    """Three viewer opens in one tick collapse to the last, no DuplicateIds."""
+    app, _session = _make_app(tmp_path)
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        strip = app.query_one("#below-prompt-slot", Container).query(AgentStripWidget).first()
+        controller = strip._open_conversation.__self__
+        run_a = _seed_run(strip, "agent-1", agent_type="explore", description="A")
+        run_b = _seed_run(strip, "agent-2", agent_type="general", description="B")
+        run_c = _seed_run(strip, "agent-3", agent_type="plan", description="C")
+        strip._manager.sources_changed()
+        await pilot.pause()
+
+        controller.open_conversation(run_a)
+        controller.open_conversation(run_b)
+        controller.open_conversation(run_c)
+        await _settle(pilot)
+
+        viewers = app.query(ConversationViewer)
+        assert len(viewers) == 1
+        assert viewers.first()._run.agent_id == "agent-3"
+        assert app._extension_component_failures_reported == set()
+
+
+async def test_same_tick_teardown_reinstall_yields_one_strip(tmp_path) -> None:  # noqa: ANN001
+    """Tearing the controller down and reinstalling in one tick -> one strip."""
+    app, _session = _make_app(tmp_path)
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        strip = app.query_one("#below-prompt-slot", Container).query(AgentStripWidget).first()
+        controller = strip._open_conversation.__self__
+
+        controller.teardown()
+        controller.install()
+        await _settle(pilot)
+
+        strips = app.query(AgentStripWidget)
+        assert len(strips) == 1, "same-tick teardown+reinstall left a duplicate strip"
+        assert app._extension_component_failures_reported == set()
+
+
+async def test_session_rebind_keeps_single_strip(tmp_path) -> None:  # noqa: ANN001
+    """The real /new,/resume rebind sequence (shutdown then start) keeps one strip.
+
+    Reproduces bug 3: the extension tears its widgets down on ``session_shutdown``
+    and reinstalls on the next ``session_start``; the old strip's deferred
+    remove() must drain before the fresh strip (same id) mounts.
+    """
+    app, session = _make_app(tmp_path)
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        assert len(app.query(AgentStripWidget)) == 1
+
+        runtime = session.extension_runtime
+        await runtime.emit_session_shutdown("new")
+        await runtime.emit_session_start("new")
+        await _settle(pilot)
+
+        strips = app.query(AgentStripWidget)
+        assert len(strips) == 1, "strip lost / duplicated across session rebind"
+        assert strips.first().has_agents() is False
+        assert app._extension_component_failures_reported == set()
+
+
+async def test_journey_switch_viewers_then_back_to_main(tmp_path) -> None:  # noqa: ANN001
+    """The user's exact journey, end to end, with zero component failures.
+
+    Spawn two real background runs -> open run 1's viewer via keys -> ``left``
+    re-activates nav while viewing -> ``down``/``enter`` switches to run 2 ->
+    ``left``, select ``main``, ``enter`` closes the viewer and restores the
+    transcript with the prompt refocused.
+    """
+    app, session = _make_app(tmp_path)
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+
+        release = asyncio.Event()
+        _patch_provider_factory(_extension_module(), _GatedProvider(release))
+        agent_tool = _agent_tool(session.extension_runtime)
+        for description, agent_type in (("survey the repo", "explore"), ("plan work", "general")):
+            result = await agent_tool.execute(
+                {
+                    "prompt": "look around",
+                    "description": description,
+                    "subagent_type": agent_type,
+                    "run_in_background": True,
+                }
+            )
+            assert result.ok, result.content
+
+        slot = app.query_one("#below-prompt-slot", Container)
+        strip = slot.query(AgentStripWidget).first()
+        await _wait_until(pilot, lambda: len(strip._agent_runs()) == 2)
+        main_slot = app.query_one("#main-slot", Container)
+
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.focus()
+        await pilot.pause()
+
+        # Open run 1's viewer via the fleet-list keys.
+        await pilot.press("left")   # activate nav on the main row
+        await pilot.press("down")   # -> first agent row
+        await pilot.press("enter")  # open its viewer
+        await _settle(pilot)
+        viewers = main_slot.query(ConversationViewer)
+        assert len(viewers) == 1
+        first_run_id = viewers.first()._run.agent_id
+        assert app.query_one("#transcript", TranscriptView).display is False
+
+        # `left` re-activates the strip nav while the viewer is open (bug fix 2).
+        await pilot.press("left")
+        await pilot.pause()
+        assert strip.nav_active is True
+
+        # `down`/`enter` switches the viewer to run 2 (race-safe swap).
+        await pilot.press("down")   # main -> agent 1
+        await pilot.press("down")   # agent 1 -> agent 2
+        await pilot.press("enter")  # switch the viewer
+        await _settle(pilot)
+        viewers = main_slot.query(ConversationViewer)
+        assert len(viewers) == 1, "switching viewers left more than one mounted"
+        second_run_id = viewers.first()._run.agent_id
+        assert second_run_id != first_run_id
+        assert strip.viewing_id == second_run_id
+        assert strip.nav_active is False  # opening reset nav
+
+        # `left`, select `main`, `enter` closes the viewer and restores main.
+        await pilot.press("left")
+        await pilot.pause()
+        assert strip.nav_active is True
+        assert strip.selected_index == 0
+        await pilot.press("enter")
+        await _settle(pilot)
+
+        assert not main_slot.query(ConversationViewer), "main row did not close the viewer"
+        assert app.query_one("#transcript", TranscriptView).display is True
+        assert main_slot.display is False
+        assert app.query_one("#prompt", PromptInput).has_focus
+        assert strip.viewing_id is None
+        assert app._extension_component_failures_reported == set()
+
+        release.set()
+        await pilot.pause()

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -1,0 +1,212 @@
+"""End-to-end integration test: the REAL ``TauTuiApp`` with the REAL extension.
+
+Every other UI test in this repo drives the widgets against a
+``FakeComponentBridge`` and runtime stubs. This test closes that gap: it builds
+the actual :class:`tau_coding.tui.app.TauTuiApp` around a minimal fake session,
+hands it a REAL :class:`~tau_coding.extensions.ExtensionRuntime` that has loaded
+the REAL ``tau_subagents`` extension, runs it under ``run_test()``, and asserts
+the extension's strip and conversation viewer actually mount into tau's
+host-owned component slots.
+
+It is the experiment's proof of life: it exercises the session_start ordering
+(host bridge attached in ``__init__`` -> ``emit_pending_session_start`` in
+``on_mount`` -> extension installs its widgets) that no isolated suite covers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from textual.containers import Container
+
+from tau_agent import QueueUpdateEvent, UserMessage
+from tau_coding.session import ModelChoice, TerminalCommandResult
+from tau_coding.skills import Skill
+from tau_coding.system_prompt import ProjectContextFile
+from tau_coding.tools import create_coding_tools
+from tau_coding.tui.app import PromptInput, TauTuiApp
+from tau_coding.tui.widgets import TranscriptView
+
+from tau_subagents.ui.strip import AgentStripWidget
+from tau_subagents.ui.viewer import ConversationViewer
+
+# Sibling test modules (pytest prepend import mode puts tests/ on sys.path).
+from test_extension import _load_runtime  # noqa: E402
+from test_ui import _run, _strip_text  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _FakeSessionState:
+    thinking_level = "medium"
+
+
+class _FakeSession:
+    """Minimal fake session that satisfies what ``TauTuiApp`` reads.
+
+    Mirrors the surface of tau's own ``tests/test_tui_app.py`` ``FakeSession``
+    (which is not packaged, so this is a local copy trimmed to the mount path),
+    plus the two hooks that make the real runtime live: an ``extension_runtime``
+    the app can bind a UI bridge to, and an ``emit_pending_session_start`` that
+    drives the runtime's real ``session_start`` fan-out (this is where the
+    extension installs its widgets).
+    """
+
+    def __init__(self, runtime, cwd: Path) -> None:  # noqa: ANN001
+        self._extension_runtime = runtime
+        self.cwd = cwd
+        self.session_id = "itest-session"
+        self.is_running = False
+        self.messages: tuple[object, ...] = ()
+        self.events: tuple[object, ...] = ()
+        self.provider_name = "openai"
+        self.model = "fake-model"
+        self.available_models = ("fake-model",)
+        self.available_model_choices = (
+            ModelChoice(provider_name="openai", model="fake-model"),
+        )
+        self.scoped_model_choices: tuple[ModelChoice, ...] = ()
+        self.available_providers = ("openai",)
+        self.tools = tuple(create_coding_tools(cwd=cwd))
+        self.skills = (Skill(name="review", path=cwd / "review.md", content="Review"),)
+        self.prompt_templates = ()
+        self.context_files = (
+            ProjectContextFile(path=str(cwd / "AGENTS.md"), content="Rules."),
+        )
+        self.context_token_estimate = 100
+        self.auto_compact_token_threshold = 200000
+        self.context_window_tokens = 216384
+        self.thinking_level = "medium"
+        self.available_thinking_levels = ("off", "low", "medium", "high")
+        self.state = _FakeSessionState()
+        self.resource_diagnostics = ()
+        self.system_prompt = "You are Tau."
+        self.session_manager = None
+        self._session_title: str | None = None
+        self.queued_steering_messages: tuple[str, ...] = ()
+        self.queued_follow_up_messages: tuple[str, ...] = ()
+        self.session_start_emissions = 0
+
+    @property
+    def extension_runtime(self):  # noqa: ANN201
+        return self._extension_runtime
+
+    async def emit_pending_session_start(self) -> None:
+        # The real ordering under test: by the time the app calls this (in
+        # on_mount), it has already attached its component bridge in __init__,
+        # so the extension's session_start handler installs a working strip.
+        self.session_start_emissions += 1
+        await self._extension_runtime.emit_session_start("startup")
+
+    @property
+    def session_title(self) -> str | None:
+        return self._session_title
+
+    def queue_update_event(self) -> QueueUpdateEvent:
+        return QueueUpdateEvent(
+            steering=self.queued_steering_messages,
+            follow_up=self.queued_follow_up_messages,
+        )
+
+    def pop_latest_follow_up_message(self) -> str | None:
+        return None
+
+    # -- BoundSession surface the extension may reach through the runtime -----
+
+    def queue_steering_message(self, content: str, **_: object) -> None:
+        self.queued_steering_messages = (*self.queued_steering_messages, content)
+
+    def queue_follow_up_message(self, content: str, **_: object) -> None:
+        self.queued_follow_up_messages = (*self.queued_follow_up_messages, content)
+
+    async def append_custom_entry(self, namespace: str, data: dict) -> None:
+        del namespace, data
+
+    async def run_terminal_command(
+        self, command: str, *, add_to_context: bool
+    ) -> TerminalCommandResult:
+        return TerminalCommandResult(
+            command=command,
+            output="",
+            exit_code=0,
+            ok=True,
+            added_to_context=add_to_context,
+        )
+
+
+def _make_app(tmp_path: Path) -> tuple[TauTuiApp, _FakeSession]:
+    project = tmp_path / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    runtime = _load_runtime(tmp_path)
+    session = _FakeSession(runtime, project)
+    # Bind so the extension's context (session_id / cwd / steering) is live;
+    # in production CodingSession.load does this. The app then attaches the
+    # real _TuiExtensionUiBridge in TauTuiApp.__init__.
+    runtime.bind(session)
+    app = TauTuiApp(session)
+    return app, session
+
+
+async def test_real_app_mounts_extension_strip_and_viewer(tmp_path) -> None:  # noqa: ANN001
+    app, session = _make_app(tmp_path)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+
+        # 1. session_start fired exactly once, through the real fan-out.
+        assert session.session_start_emissions == 1
+
+        # 2. The extension installed its strip into tau's #below-prompt-slot.
+        slot = app.query_one("#below-prompt-slot", Container)
+        strips = slot.query(AgentStripWidget)
+        assert len(strips) == 1, "extension strip did not mount into the host slot"
+        strip = strips.first()
+        assert strip.has_agents() is False  # no runs yet
+
+        # 3. A run appears in the real manager; the manager's change signal
+        #    (repointed at the controller by the extension) refreshes the strip.
+        manager = strip._manager  # the real SubagentManager from setup()
+        assert manager.sources_changed is not None, "controller never wired the push"
+        run = _run(
+            "agent-1",
+            agent_type="explore",
+            description="survey the repo",
+            status="running",
+            session=SimpleNamespace(messages=()),
+        )
+        manager.runs["agent-1"] = run
+        manager.sources_changed()
+        await pilot.pause()
+        assert strip.has_agents() is True
+        assert "explore" in _strip_text(strip)
+
+        # 4. Opening the conversation (through the controller, via the strip's
+        #    bound callback) mounts the viewer into #main-slot and hides the
+        #    main transcript in place.
+        opened = strip._open_conversation(run)
+        assert opened is True
+        await pilot.pause()
+
+        main_slot = app.query_one("#main-slot", Container)
+        viewers = main_slot.query(ConversationViewer)
+        assert len(viewers) == 1, "viewer did not mount into the host main slot"
+        assert app.query_one("#transcript", TranscriptView).display is False
+        assert main_slot.display is True
+
+        # 5. Closing the view restores the main transcript and drops the viewer.
+        assert app._extension_main_view is not None
+        app._extension_main_view.close()
+        await pilot.pause()
+
+        assert not app.query("#subagents-conversation-viewer")
+        assert app.query_one("#transcript", TranscriptView).display is True
+        assert app.query_one("#main-slot", Container).display is False
+        # Focus returned to the host prompt.
+        assert app.query_one("#prompt", PromptInput).has_focus

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -558,3 +558,25 @@ async def test_setup_skips_components_on_null_host(tmp_path) -> None:  # noqa: A
     assert runtime.ui.supports_components is False
     # Must not raise, and nothing to assert beyond a clean session_start.
     await runtime.emit_session_start("startup")
+
+
+async def test_setup_survives_component_less_core(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # Simulate an OLDER tau whose ``context.ui`` predates the component seam:
+    # the ``components`` attribute is absent entirely (not merely a no-op
+    # bridge). The extension's getattr-guard must degrade to dialog-only rather
+    # than crash session_start (constraint 8).
+    from tau_coding.extensions.api import ExtensionUi
+
+    monkeypatch.delattr(ExtensionUi, "components", raising=True)
+    runtime = _load_runtime(tmp_path)
+    session = RecordingSession(tmp_path)
+    runtime.bind(session)
+
+    bridge = FakeComponentBridge()  # a real component host is present…
+    runtime.set_ui_bridge(bridge)
+    # …but the facade no longer exposes `.components`, so the guard sees None.
+    await runtime.emit_session_start("startup")
+
+    # No strip / interceptor installed, and no exception surfaced.
+    assert bridge.slot_calls == []
+    assert bridge.interceptors == []

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -32,7 +32,7 @@ from tau_coding.tui.widgets import TranscriptMessageWidget
 
 from tau_subagents.extension import AgentRun, SubagentManager
 from tau_subagents.ui.controller import STRIP_KEY, SubagentUiController
-from tau_subagents.ui.strip import _SPINNER_FRAMES, AgentStripWidget
+from tau_subagents.ui.strip import AgentStripWidget
 from tau_subagents.ui.viewer import ConversationViewer
 
 # Sibling test module (pytest prepend import mode puts tests/ on sys.path).
@@ -118,10 +118,14 @@ def test_strip_renders_runs_and_statuses() -> None:
     assert "main" in text
     for label in ("explore", "review", "build"):
         assert label in text
-    # Running shows a braille spinner; finished statuses render their own glyph.
-    assert any(frame in text for frame in _SPINNER_FRAMES)
+    # Running shows a hollow circle (the animated spinner lives on the agent
+    # tool row in the main chat, not the strip); finished statuses render their
+    # own glyph. No timer/token stats in strip rows.
+    assert "○ explore" in text
     assert "✓" in text  # completed
     assert "✗" in text  # error
+    assert "tokens" not in text
+    assert "0s" not in text
 
 
 def test_strip_renders_steered_and_aborted_glyphs() -> None:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,560 @@
+"""Tests for the extension-owned Textual widgets (component seam).
+
+Two layers, per the design's test plan:
+
+* Widget behaviour — mount the strip / viewer in a minimal Textual test ``App``
+  and drive them with :class:`~tau_subagents.extension.AgentRun` instances and a
+  ``SimpleNamespace`` manager (no full host wiring needed).
+* Seam wiring — a ``FakeComponentBridge`` implementing tau's
+  :class:`ComponentBridge`, exercising the controller's registrations and the
+  key interceptor, plus a runtime-level check that ``setup()`` registers on a
+  component host and skips cleanly on a null host.
+
+These re-home the behaviours the deleted core UX pilot tests used to cover
+(fills-only-viewed-dot, drops-finished, click-switches, opens+steers,
+rejects-finished-steer, rerenders-on-change).
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.events import Key
+from textual.widgets import Input
+
+from tau_agent.messages import AssistantMessage, UserMessage
+from tau_coding.tui.app import _theme_css_variables
+from tau_coding.tui.config import TAU_DARK_THEME
+from tau_coding.tui.widgets import TranscriptMessageWidget
+
+from tau_subagents.extension import AgentRun, SubagentManager
+from tau_subagents.ui.controller import STRIP_KEY, SubagentUiController
+from tau_subagents.ui.strip import _SPINNER_FRAMES, AgentStripWidget
+from tau_subagents.ui.viewer import ConversationViewer
+
+# Sibling test module (pytest prepend import mode puts tests/ on sys.path).
+from test_extension import RecordingSession, _load_runtime  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _run(
+    agent_id: str = "agent-1",
+    *,
+    agent_type: str = "explore",
+    description: str = "survey",
+    status: str = "running",
+    started: bool = True,
+    finished: bool = False,
+    session: object | None = None,
+) -> AgentRun:
+    run = AgentRun(
+        agent_id=agent_id,
+        agent_type=agent_type,
+        description=description,
+        prompt="child prompt",
+        background=True,
+        status=status,
+    )
+    if started:
+        run.started_at = time.monotonic()
+    if finished:
+        run.completed_at = time.monotonic()
+    run.session = session
+    return run
+
+
+def _manager(*runs: AgentRun) -> SimpleNamespace:
+    return SimpleNamespace(runs={run.agent_id: run for run in runs})
+
+
+class _Harness(App):
+    """Minimal app that mounts an ``#prompt`` plus the widgets under test."""
+
+    def __init__(self, *widgets) -> None:  # noqa: ANN002
+        super().__init__()
+        self._widgets = widgets
+
+    def get_css_variables(self) -> dict[str, str]:
+        # The reused TranscriptView (and its markdown widgets) reference tau's
+        # $tau-* CSS variables, which the real TauTuiApp provides from the theme.
+        variables = super().get_css_variables()
+        variables.update(_theme_css_variables(TAU_DARK_THEME))
+        return variables
+
+    def compose(self) -> ComposeResult:
+        yield Input(id="prompt")
+        yield from self._widgets
+
+
+def _strip_text(strip: AgentStripWidget) -> str:
+    group = strip.render()
+    return " ".join(getattr(part, "plain", "") for part in group.renderables)
+
+
+# --- strip rendering -------------------------------------------------------
+
+
+def test_strip_renders_runs_and_statuses() -> None:
+    # Kept within STRIP_MAX_ROWS so every row is visible (no overflow window).
+    running = _run("agent-1", agent_type="explore", status="running")
+    done = _run("agent-2", agent_type="review", status="completed", finished=True)
+    errored = _run("agent-3", agent_type="build", status="error", finished=True)
+    manager = _manager(running, done, errored)
+    strip = AgentStripWidget(manager, TAU_DARK_THEME, open_conversation=lambda run: True)
+
+    text = _strip_text(strip)
+    assert "main" in text
+    for label in ("explore", "review", "build"):
+        assert label in text
+    # Running shows a braille spinner; finished statuses render their own glyph.
+    assert any(frame in text for frame in _SPINNER_FRAMES)
+    assert "✓" in text  # completed
+    assert "✗" in text  # error
+
+
+def test_strip_renders_steered_and_aborted_glyphs() -> None:
+    # steered/aborted render directly, no down-mapping onto the old vocabulary.
+    steered = _run("agent-1", agent_type="plan", status="steered", finished=True)
+    aborted = _run("agent-2", agent_type="test", status="aborted", finished=True)
+    strip = AgentStripWidget(
+        _manager(steered, aborted), TAU_DARK_THEME, open_conversation=lambda run: True
+    )
+    text = _strip_text(strip)
+    assert "↻" in text  # steered
+    assert "⊘" in text  # aborted
+
+
+def test_strip_drops_finished_agents_after_linger() -> None:
+    running = _run("agent-1", agent_type="explore", status="running")
+    stale = _run("agent-2", agent_type="review", status="completed")
+    # Finished well outside the linger window → dropped from the strip.
+    stale.completed_at = time.monotonic() - 3600
+    strip = AgentStripWidget(
+        _manager(running, stale), TAU_DARK_THEME, open_conversation=lambda run: True
+    )
+
+    text = _strip_text(strip)
+    assert "explore" in text
+    assert "review" not in text
+
+
+def test_strip_shows_overflow_line() -> None:
+    runs = [_run(f"agent-{i}", agent_type=f"t{i}", status="running") for i in range(6)]
+    strip = AgentStripWidget(_manager(*runs), TAU_DARK_THEME, open_conversation=lambda r: True)
+    text = _strip_text(strip)
+    assert "more — /agents" in text
+
+
+def test_strip_marks_only_the_viewed_row() -> None:
+    a = _run("agent-1", agent_type="explore", status="running")
+    b = _run("agent-2", agent_type="review", status="running")
+    strip = AgentStripWidget(_manager(a, b), TAU_DARK_THEME, open_conversation=lambda r: True)
+    # Nothing viewed → the filled ● dot sits on main only.
+    assert _strip_text(strip).count("●") == 1
+    strip.viewing_id = "agent-2"
+    # Viewing an agent moves the single filled dot to it (main goes hollow).
+    assert _strip_text(strip).count("●") == 1
+
+
+# --- strip navigation ------------------------------------------------------
+
+
+async def test_strip_enter_and_leave_returns_focus_to_prompt() -> None:
+    run = _run("agent-1", status="running")
+    opened: list[str] = []
+    strip = AgentStripWidget(
+        _manager(run), TAU_DARK_THEME, open_conversation=lambda r: opened.append(r.agent_id)
+    )
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        strip.enter_strip()
+        await pilot.pause()
+        assert strip.has_focus
+
+        # Down selects the first agent row (index 1); Enter opens it.
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert opened == ["agent-1"]
+
+        # Re-enter, then Esc hands focus back to the prompt.
+        strip.enter_strip()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one("#prompt", Input).has_focus
+
+
+async def test_strip_up_past_top_leaves_to_prompt() -> None:
+    run = _run("agent-1", status="running")
+    strip = AgentStripWidget(_manager(run), TAU_DARK_THEME, open_conversation=lambda r: True)
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        strip.enter_strip()  # selection at main (index 0)
+        await pilot.pause()
+        await pilot.press("up")  # up-past-top exits
+        await pilot.pause()
+        assert app.query_one("#prompt", Input).has_focus
+
+
+# --- viewer ----------------------------------------------------------------
+
+
+class _FakeHandle:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    @property
+    def is_open(self) -> bool:
+        return not self.closed
+
+
+def _viewer_for(run: AgentRun, handle: _FakeHandle | None = None) -> ConversationViewer:
+    return ConversationViewer(
+        run, handle or _FakeHandle(), _manager(run), TAU_DARK_THEME
+    )
+
+
+async def test_viewer_renders_messages_and_header() -> None:
+    session = SimpleNamespace(
+        messages=(UserMessage(content="do the thing"), AssistantMessage(content="on it")),
+        queue_steering_message=lambda msg: None,
+    )
+    run = _run("agent-1", agent_type="explore", status="running", session=session)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        texts = [w.item.text for w in viewer.query(TranscriptMessageWidget)]
+        assert any("on it" in t for t in texts)
+        # Header carries label + status.
+        header_plain = viewer._header_text.plain
+        assert "explore" in header_plain
+        assert "[running]" in header_plain
+
+
+async def test_viewer_composer_steers_the_run() -> None:
+    run = _run("agent-1", status="running", session=None)  # no session → pending
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert viewer.has_focus
+        await pilot.press("enter")  # open the steer composer
+        await pilot.pause()
+        assert viewer._composer is not None
+        await pilot.press("g", "o", "!")
+        await pilot.press("enter")  # submit
+        await pilot.pause()
+        assert run.pending_steers == ["go!"]
+        assert viewer._composer is None  # composer closed after send
+
+
+async def test_viewer_steers_live_session() -> None:
+    steered: list[str] = []
+    session = SimpleNamespace(messages=(), queue_steering_message=steered.append)
+    run = _run("agent-1", status="running", session=session)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert steered == ["hi"]
+
+
+async def test_viewer_composer_escape_cancels_without_steering() -> None:
+    run = _run("agent-1", status="running", session=None)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("enter")  # open composer
+        await pilot.pause()
+        assert viewer._composer is not None
+        await pilot.press("a", "b")
+        await pilot.press("escape")  # cancel composer (pi parity: not the view)
+        await pilot.pause()
+        assert viewer._composer is None
+        assert run.pending_steers == []  # nothing sent
+
+
+async def test_viewer_two_press_stop_guard() -> None:
+    run = _run("agent-1", status="running", session=None)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("x")  # arms
+        await pilot.pause()
+        assert viewer._stop_armed is True
+        assert run.aborted is False
+        await pilot.press("x")  # confirms
+        await pilot.pause()
+        assert run.aborted is True  # stop_run fired
+
+
+async def test_viewer_stop_disarms_on_other_key() -> None:
+    run = _run("agent-1", status="running", session=None)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+        assert viewer._stop_armed is True
+        await pilot.press("down")  # any other key disarms (then scrolls)
+        await pilot.pause()
+        assert viewer._stop_armed is False
+        assert run.aborted is False
+
+
+async def test_viewer_escape_closes() -> None:
+    handle = _FakeHandle()
+    run = _run("agent-1", status="running", session=None)
+    viewer = _viewer_for(run, handle)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert handle.closed is True
+
+
+async def test_viewer_cannot_steer_finished_run() -> None:
+    # A finished run offers no steer affordance: Enter must not open a composer.
+    run = _run("agent-1", status="completed", session=None, finished=True)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert viewer._composer is None
+
+
+async def test_viewer_push_listener_rerenders_on_new_message() -> None:
+    session = SimpleNamespace(
+        messages=[UserMessage(content="start")], queue_steering_message=lambda m: None
+    )
+    run = _run("agent-1", status="running", session=session)
+    viewer = _viewer_for(run)
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert run.listeners  # viewer subscribed on mount
+        session.messages.append(AssistantMessage(content="progress update"))
+        # Fire the per-run push (the analog of manager._notify_run).
+        for listener in list(run.listeners):
+            listener()
+        await pilot.pause()
+        texts = [w.item.text for w in viewer.query(TranscriptMessageWidget)]
+        assert any("progress update" in t for t in texts)
+
+
+async def test_viewer_unsubscribes_on_unmount() -> None:
+    run = _run("agent-1", status="running", session=None)
+    closed: list[int] = []
+    viewer = ConversationViewer(
+        run, _FakeHandle(), _manager(run), TAU_DARK_THEME, on_close=lambda: closed.append(1)
+    )
+    app = _Harness(viewer)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert run.listeners
+        # The host removes the widget when its handle closes; unmount unsubscribes.
+        await viewer.remove()
+        await pilot.pause()
+        assert run.listeners == []  # listener removed on unmount
+        assert closed == [1]  # on_close notified the controller
+
+
+# --- push at the manager level ---------------------------------------------
+
+
+def test_manager_notify_run_fires_listeners() -> None:
+    manager = SubagentManager(SimpleNamespace())
+    run = _run("agent-1")
+    fired: list[int] = []
+    run.listeners.append(lambda: fired.append(1))
+    manager._notify_run(run)
+    assert fired == [1]
+
+
+# --- component-seam wiring --------------------------------------------------
+
+
+class FakeComponentBridge:
+    """Records ComponentBridge calls; feeds synthetic keys to interceptors."""
+
+    def __init__(self, *, supports: bool = True) -> None:
+        self._supports = supports
+        self.theme = TAU_DARK_THEME
+        self.prompt_text = ""
+        self.slot_calls: list[tuple[str, object, str]] = []
+        self.slots: dict[str, object] = {}
+        self.interceptors: list = []
+        self.main_views: list = []
+        self.render_requests = 0
+        self.has_ui = True
+
+    @property
+    def supports_components(self) -> bool:
+        return self._supports
+
+    def get_prompt_text(self) -> str:
+        return self.prompt_text
+
+    def request_render(self) -> None:
+        self.render_requests += 1
+
+    def set_slot_widget(self, key, factory, *, placement="below_prompt"):  # noqa: ANN001
+        self.slot_calls.append((key, factory, placement))
+        if factory is None:
+            self.slots.pop(key, None)
+        else:
+            self.slots[key] = factory
+
+    def open_main_view(self, factory):  # noqa: ANN001
+        handle = _FakeHandle()
+        widget = factory(handle, self.theme)
+        self.main_views.append((handle, widget))
+        return handle
+
+    def register_key_interceptor(self, handler):  # noqa: ANN001
+        self.interceptors.append(handler)
+
+        def unsub() -> None:
+            if handler in self.interceptors:
+                self.interceptors.remove(handler)
+
+        return unsub
+
+
+def test_controller_install_registers_slot_and_interceptor() -> None:
+    manager = _manager()
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(manager, bridge)
+    controller.install()
+
+    assert [key for key, _f, _p in bridge.slot_calls] == [STRIP_KEY]
+    assert bridge.slot_calls[0][2] == "below_prompt"
+    assert len(bridge.interceptors) == 1
+
+    # Teardown unregisters the interceptor and clears the slot.
+    controller.teardown()
+    assert bridge.interceptors == []
+    assert (STRIP_KEY, None, "below_prompt") in bridge.slot_calls
+
+
+def test_controller_open_conversation_uses_main_view() -> None:
+    run = _run("agent-1", status="running")
+    controller = SubagentUiController(_manager(run), FakeComponentBridge())
+    assert controller.open_conversation(run) is True
+    assert controller._components.main_views  # type: ignore[attr-defined]
+    handle, widget = controller._components.main_views[0]  # type: ignore[attr-defined]
+    assert isinstance(widget, ConversationViewer)
+
+
+def test_controller_open_conversation_degrades_without_components() -> None:
+    run = _run("agent-1", status="running")
+    controller = SubagentUiController(_manager(run), FakeComponentBridge(supports=False))
+    assert controller.open_conversation(run) is False
+
+
+async def test_controller_interceptor_enters_strip() -> None:
+    run = _run("agent-1", status="running")
+    manager = _manager(run)
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(manager, bridge)
+    controller.install()
+    strip_factory = bridge.slots[STRIP_KEY]
+    interceptor = bridge.interceptors[0]
+
+    # Build + mount the strip via the captured factory (this sets controller._strip).
+    strip = strip_factory(TAU_DARK_THEME)
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # Non-empty prompt → not consumed (pi's empty-editor gate).
+        assert interceptor(Key("left", None), "hello") is False
+        # Empty prompt + left/down with agents present → enters the strip.
+        assert interceptor(Key("left", None), "") is True
+        await pilot.pause()
+        assert strip.has_focus
+
+
+async def test_controller_interceptor_ignored_without_agents() -> None:
+    manager = _manager()  # no runs
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(manager, bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert interceptor(Key("down", None), "") is False
+
+
+async def test_controller_on_change_refreshes_strip_after_spawn() -> None:
+    manager = _manager()
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(manager, bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert strip.has_agents() is False
+        # A run appears; the manager's change signal re-renders the strip.
+        manager.runs["agent-1"] = _run("agent-1", agent_type="explore", status="running")
+        controller.on_change()
+        await pilot.pause()
+        assert "explore" in _strip_text(strip)
+
+
+# --- setup() wiring at the runtime level -----------------------------------
+
+
+async def test_setup_registers_components_on_component_host(tmp_path) -> None:  # noqa: ANN001
+    runtime = _load_runtime(tmp_path)
+    session = RecordingSession(tmp_path)
+    runtime.bind(session)
+    bridge = FakeComponentBridge()
+    runtime.set_ui_bridge(bridge)
+
+    await runtime.emit_session_start("startup")
+
+    assert [key for key, _f, _p in bridge.slot_calls] == [STRIP_KEY]
+    assert len(bridge.interceptors) == 1
+
+
+async def test_setup_skips_components_on_null_host(tmp_path) -> None:  # noqa: ANN001
+    runtime = _load_runtime(tmp_path)
+    session = RecordingSession(tmp_path)
+    runtime.bind(session)
+    # Default runtime.ui is the print-mode NullUiBridge (supports_components False).
+    assert runtime.ui.supports_components is False
+    # Must not raise, and nothing to assert beyond a clean session_start.
+    await runtime.emit_session_start("startup")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -168,46 +168,43 @@ def test_strip_marks_only_the_viewed_row() -> None:
     assert _strip_text(strip).count("●") == 1
 
 
-# --- strip navigation ------------------------------------------------------
+# --- strip navigation (controller-driven; the strip never takes focus) -----
 
 
-async def test_strip_enter_and_leave_returns_focus_to_prompt() -> None:
-    run = _run("agent-1", status="running")
-    opened: list[str] = []
-    strip = AgentStripWidget(
-        _manager(run), TAU_DARK_THEME, open_conversation=lambda r: opened.append(r.agent_id)
-    )
+async def test_strip_nav_mutators_track_selection() -> None:
+    a = _run("agent-1", agent_type="explore", status="running")
+    b = _run("agent-2", agent_type="review", status="running")
+    strip = AgentStripWidget(_manager(a, b), TAU_DARK_THEME, open_conversation=lambda r: True)
     app = _Harness(strip)
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
-        strip.enter_strip()
-        await pilot.pause()
-        assert strip.has_focus
 
-        # Down selects the first agent row (index 1); Enter opens it.
-        await pilot.press("down")
-        await pilot.press("enter")
-        await pilot.pause()
-        assert opened == ["agent-1"]
+        assert strip.nav_active is False
+        assert strip.selected_index == 0
 
-        # Re-enter, then Esc hands focus back to the prompt.
-        strip.enter_strip()
-        await pilot.pause()
-        await pilot.press("escape")
-        await pilot.pause()
-        assert app.query_one("#prompt", Input).has_focus
+        strip.activate_nav()
+        assert strip.nav_active is True
+        assert strip.selected_index == 0  # highlights the main row
+        assert strip.selected_run() is None  # main row → no run
 
+        strip.move_selection(1)
+        assert strip.selected_index == 1
+        assert strip.selected_run() is a  # first agent row
 
-async def test_strip_up_past_top_leaves_to_prompt() -> None:
-    run = _run("agent-1", status="running")
-    strip = AgentStripWidget(_manager(run), TAU_DARK_THEME, open_conversation=lambda r: True)
-    app = _Harness(strip)
-    async with app.run_test(size=(80, 24)) as pilot:
-        await pilot.pause()
-        strip.enter_strip()  # selection at main (index 0)
-        await pilot.pause()
-        await pilot.press("up")  # up-past-top exits
-        await pilot.pause()
+        strip.move_selection(1)
+        assert strip.selected_index == 2
+        assert strip.selected_run() is b
+
+        # Clamped at the last row (no wrap).
+        strip.move_selection(1)
+        assert strip.selected_index == 2
+
+        strip.deactivate_nav()
+        assert strip.nav_active is False
+        assert strip.selected_index == 0
+
+        # The strip is never focusable — the prompt keeps focus throughout.
+        assert strip.can_focus is False
         assert app.query_one("#prompt", Input).has_focus
 
 
@@ -482,26 +479,86 @@ def test_controller_open_conversation_degrades_without_components() -> None:
     assert controller.open_conversation(run) is False
 
 
-async def test_controller_interceptor_enters_strip() -> None:
+async def test_controller_interceptor_drives_nav_and_opens_viewer() -> None:
     run = _run("agent-1", status="running")
     manager = _manager(run)
     bridge = FakeComponentBridge()
     controller = SubagentUiController(manager, bridge)
     controller.install()
-    strip_factory = bridge.slots[STRIP_KEY]
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
     interceptor = bridge.interceptors[0]
-
-    # Build + mount the strip via the captured factory (this sets controller._strip).
-    strip = strip_factory(TAU_DARK_THEME)
     app = _Harness(strip)
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         # Non-empty prompt → not consumed (pi's empty-editor gate).
         assert interceptor(Key("left", None), "hello") is False
-        # Empty prompt + left/down with agents present → enters the strip.
+        assert strip.nav_active is False
+        # Empty prompt + left activates nav — the strip NEVER takes focus.
         assert interceptor(Key("left", None), "") is True
+        assert strip.nav_active is True
+        assert strip.selected_index == 0
+        assert app.query_one("#prompt", Input).has_focus
+        # Down moves onto the agent row; Enter opens its viewer via the bridge.
+        assert interceptor(Key("down", None), "") is True
+        assert strip.selected_index == 1
+        assert interceptor(Key("enter", None), "") is True
+        assert bridge.main_views, "Enter on the agent row did not open a viewer"
+        # Opening a viewer resets the strip's nav state.
+        assert strip.nav_active is False
+
+
+async def test_controller_interceptor_escape_and_up_deactivate() -> None:
+    run = _run("agent-1", status="running")
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(_manager(run), bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
-        assert strip.has_focus
+        interceptor(Key("down", None), "")  # activate (highlight main)
+        assert strip.nav_active is True
+        # Escape deactivates.
+        assert interceptor(Key("escape", None), "") is True
+        assert strip.nav_active is False
+        # Re-activate; up-past-top deactivates.
+        interceptor(Key("down", None), "")
+        assert interceptor(Key("up", None), "") is True
+        assert strip.nav_active is False
+
+
+async def test_controller_interceptor_other_key_flows_to_prompt() -> None:
+    run = _run("agent-1", status="running")
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(_manager(run), bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        interceptor(Key("down", None), "")  # activate
+        # A typed character cancels nav and is NOT consumed (flows to the prompt).
+        assert interceptor(Key("a", None), "") is False
+        assert strip.nav_active is False
+
+
+async def test_controller_interceptor_yields_while_viewer_open() -> None:
+    run = _run("agent-1", status="running", session=SimpleNamespace(messages=()))
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(_manager(run), bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        controller.open_conversation(run)
+        assert controller._viewer is not None
+        # While a viewer/composer owns focus, the interceptor yields every key.
+        assert interceptor(Key("left", None), "") is False
+        assert interceptor(Key("down", None), "") is False
 
 
 async def test_controller_interceptor_ignored_without_agents() -> None:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -544,7 +544,12 @@ async def test_controller_interceptor_other_key_flows_to_prompt() -> None:
         assert strip.nav_active is False
 
 
-async def test_controller_interceptor_yields_while_viewer_open() -> None:
+async def test_controller_interceptor_nav_stays_live_while_viewer_open() -> None:
+    """A viewer being open must NOT strand strip nav (bug fix 2).
+
+    ``left`` re-activates the strip while a viewer is up; ``down`` is left to the
+    focused viewer for scrolling; ``enter`` on the ``main`` row closes the viewer.
+    """
     run = _run("agent-1", status="running", session=SimpleNamespace(messages=()))
     bridge = FakeComponentBridge()
     controller = SubagentUiController(_manager(run), bridge)
@@ -556,9 +561,102 @@ async def test_controller_interceptor_yields_while_viewer_open() -> None:
         await pilot.pause()
         controller.open_conversation(run)
         assert controller._viewer is not None
-        # While a viewer/composer owns focus, the interceptor yields every key.
-        assert interceptor(Key("left", None), "") is False
+        handle = bridge.main_views[0][0]
+
+        # Nav inactive + viewer open: `down` belongs to the focused viewer (scroll).
         assert interceptor(Key("down", None), "") is False
+        assert strip.nav_active is False
+        # `left` re-activates strip nav even while the viewer is up.
+        assert interceptor(Key("left", None), "") is True
+        assert strip.nav_active is True
+        assert strip.selected_index == 0
+        # `enter` on the main row closes the viewer and returns to the prompt.
+        assert interceptor(Key("enter", None), "") is True
+        assert handle.closed is True
+        assert strip.nav_active is False
+
+
+async def test_controller_interceptor_enter_agent_switches_viewer() -> None:
+    """`enter` on another agent row while a viewer is open switches the viewer."""
+    run_a = _run("agent-1", status="running", session=SimpleNamespace(messages=()))
+    run_b = _run("agent-2", status="running", session=SimpleNamespace(messages=()))
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(_manager(run_a, run_b), bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        controller.open_conversation(run_a)
+        assert len(bridge.main_views) == 1
+        # Re-enter nav, move onto run_b's row, enter switches the viewer.
+        assert interceptor(Key("left", None), "") is True
+        assert interceptor(Key("down", None), "") is True  # main -> agent 1
+        assert interceptor(Key("down", None), "") is True  # agent 1 -> agent 2
+        assert strip.selected_index == 2
+        assert interceptor(Key("enter", None), "") is True
+        assert len(bridge.main_views) == 2  # a new viewer opened for run_b
+        assert controller._viewing_id == "agent-2"
+        assert strip.viewing_id == "agent-2"
+        assert strip.nav_active is False  # opening resets nav
+
+
+async def test_controller_interceptor_yields_while_composer_active() -> None:
+    """While the steer composer owns the keyboard, the interceptor yields."""
+    run = _run("agent-1", status="running", session=SimpleNamespace(messages=()))
+    bridge = FakeComponentBridge()
+    controller = SubagentUiController(_manager(run), bridge)
+    controller.install()
+    strip = bridge.slots[STRIP_KEY](TAU_DARK_THEME)
+    interceptor = bridge.interceptors[0]
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        controller.open_conversation(run)
+        # Simulate the composer being up (it owns keys until it closes).
+        controller._viewer._composer = object()  # type: ignore[attr-defined]
+        assert controller._viewer.composer_active is True
+        assert interceptor(Key("left", None), "") is False
+        assert interceptor(Key("escape", None), "") is False
+
+
+async def test_strip_click_main_row_closes_open_viewer() -> None:
+    """Clicking the ``main`` row while a viewer is open closes it (bug fix 2)."""
+    run = _run("agent-1", status="running", session=SimpleNamespace(messages=()))
+    closed: list[int] = []
+
+    def _close() -> bool:
+        closed.append(1)
+        return True
+
+    strip = AgentStripWidget(
+        _manager(run),
+        TAU_DARK_THEME,
+        open_conversation=lambda r: True,
+        close_conversation=_close,
+    )
+    strip.viewing_id = "agent-1"
+    app = _Harness(strip)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # render() populated _row_runs; index 0 is the main row (None).
+        assert strip._row_runs[0] is None
+        strip.on_click(SimpleNamespace(y=0))  # type: ignore[arg-type]
+        assert closed == [1]
+        # With no viewer open, the main-row click just deactivates nav.
+        closed_none = AgentStripWidget(
+            _manager(run),
+            TAU_DARK_THEME,
+            open_conversation=lambda r: True,
+            close_conversation=lambda: False,
+        )
+        app2 = _Harness(closed_none)
+        async with app2.run_test(size=(80, 24)) as pilot2:
+            await pilot2.pause()
+            closed_none.activate_nav()
+            closed_none.on_click(SimpleNamespace(y=0))  # type: ignore[arg-type]
+            assert closed_none.nav_active is False
 
 
 async def test_controller_interceptor_ignored_without_agents() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -323,18 +323,26 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "tau-ai" },
+    { name = "textual" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "tau-ai", editable = "/Users/rian/.herdr/worktrees/tau/worktree-extensions" }]
+requires-dist = [
+    { name = "tau-ai", editable = "/Users/rian/.herdr/worktrees/tau/worktree-extensions" },
+    { name = "textual", specifier = ">=1.0" },
+]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "pytest", specifier = ">=8.0" },
+]
 
 [[package]]
 name = "textual"


### PR DESCRIPTION
## What & why

This branch reopens a deliberate architecture experiment: **remove tau core's
`transcript-sources` seam and re-implement the agents UI as extension-owned
Textual widgets over a generic *component seam* (`context.ui.components`).**

Previously the agents strip, in-place conversation views, and steer-by-typing
lived in tau core (`AgentStrip`, `TranscriptSource`,
`set_transcript_source_provider`, `ui.view_transcript`). The boundary audit
flagged that as agent-flavored UX leaking into a supposedly subagent-agnostic
core. Here the extension owns that UX end to end, mounting its own widgets on
a generic seam — closer to pi's `ctx.ui.custom` model while keeping tau core
honestly generic.

## What changed

- **New `src/tau_subagents/ui/` package** — the agents UI as extension widgets:
  - `controller.py` — wires the widgets to the component seam and run state.
  - `strip.py` — the fleet strip under the prompt (status glyphs, focus-free
    navigation, reachable while a viewer is open).
  - `viewer.py` — in-place agent conversation view + live stats ticker.
- **`extension.py` / `notification_render.py` / `agents_menu.py`** — rewired to
  drive the extension-owned widgets instead of core's transcript-sources seam.
- **Completion cards** — foreground finishes render as `render_result`
  completion cards that join the card family, with a live stats ticker and a
  budget-style turn count (`3 turns (max 8)`).
- **Esc / cancel hardening** — Esc cascades to the foreground child (pi's
  parent-abort); `cancel_child` never swallows a self-directed cancel and
  settles before close; ticker survives hard-cancel; no phantom cancellation
  or `0m 59s` artifacts.
- **Tests** — new `tests/test_ui.py` (741 lines) and
  `tests/test_integration_tui.py` (582 lines); `tests/test_extension.py`
  reworked. README + HANDOFF docs updated to describe the component seam.

## Notes for reviewers

- The extension still feature-detects its tau seams and degrades on plain
  `worktree-extensions` (compatibility is a hard requirement).
- The two HANDOFF docs carry banners marking which prior decisions this
  experiment supersedes (and which stand again if it's discarded).
- This is an experiment branch — the corresponding tau-core changes live on
  the tau fork; see `HANDOFF.md` for the branch stack.

## Test plan

- [ ] `uv run pytest` (repo env; tau resolved via pyproject path source)
- [ ] Live smoke: spawn a foreground subagent, confirm strip + in-place view +
      completion card render; Esc cascades to the child; background completion
      renders as a card.
