### PR TITLE
docs: use current extension flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ extensions = ["src/tau_subagents/extension.py"]`), so the repo itself is
 loadable as a Tau extension. Either try it per-run:
 
 ```bash
-tau -x /path/to/tau-subagents
+tau -e /path/to/tau-subagents
 ```
 
 or install it permanently by symlinking the clone into Tau's user extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 dev = ["pytest>=8.0", "anyio>=4.0"]
 
 # Tau extension manifest (tau branch `extension-manifest`, ported from pi's
-# package.json "pi.extensions"): lets `tau -x` on this repo root find the
+# package.json "pi.extensions"): lets `tau -e` on this repo root find the
 # entry inside the src layout, no root shim needed.
 [tool.tau]
 extensions = ["src/tau_subagents/extension.py"]

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -13,7 +13,7 @@ as slots free up.
 
 Install by copying this directory into `~/.tau/extensions/subagents/`, or run:
 
-    tau -x examples/extensions/subagents
+    tau -e examples/extensions/subagents
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- replace the removed `tau -x` extension flag with `tau -e` in installation guidance
- update the manifest comment and extension module docstring to match Tau 0.3

## Testing
- `uv run pytest -q` (134 passed)