### PR TITLE
Require tau-ai 0.3.0 and strip pre-0.3.0 feature detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 Claude Code-style autonomous subagents for [Tau](https://github.com/huggingface/tau),
 ported from [pi-subagents](https://github.com/tintinweb/pi-subagents).
 
-> **Targets upstream tau-ai ≥ 0.2.0** (migrated 2026-07-16). Upstream tau
-> adopted pi's event and extension protocol wholesale (`feat: adopt
-> Pi-compatible event and extension protocol`, tau #375), and every capability
-> this extension once needed from the rian-dolphin/tau fork's seam branches
-> now exists upstream. Where the text below says a feature needs a particular
-> *seam* or fork branch, read that as historical: on tau-ai 0.2.0 they are all
-> present, and the extension's feature-detection simply always finds them.
+> **Requires upstream tau-ai ≥ 0.3.0.** Upstream tau adopted pi's event and
+> extension protocol wholesale (tau #375), so everything this extension needs
+> — the extension API, the component seam, dialogs, message renderers, the
+> `skills_enabled` config, provider usage fields — is present in every
+> supported Tau. Older 0.2.x releases (and the pre-0.2.0 fork branches) are no
+> longer supported.
 
 Gives the model an `agent` tool that delegates a task to a **subagent** — a
 second, scoped Tau coding session running in-process with its own system
@@ -23,9 +22,8 @@ Also registers:
 - `get_subagent_result` — poll a background agent, or `wait=true` to block for it
 - `steer_subagent` — inject a message into a running (or queued) agent
 - `/agents` — interactive menu over agent types, runs, and scheduled jobs
-- an **agents strip** under the prompt (Tau builds with the component seam):
-  live subagent list with an embedded conversation viewer (see "The agents
-  strip")
+- an **agents strip** under the prompt (TUI mode): live subagent list with an
+  embedded conversation viewer (see "The agents strip")
 
 ## Install
 
@@ -47,9 +45,9 @@ ln -s ~/code/tau-subagents ~/.tau/extensions/tau-subagents
 
 Update with `git pull`, then restart `tau` (or `/reload`).
 
-Beyond Tau, this branch takes a direct dependency on `textual`: on the
-`component-seam-experiment` branch the agents strip and conversation viewer are
-extension-owned Textual widgets (see "The agents strip").
+Beyond Tau, the extension takes a direct dependency on `textual`: the agents
+strip and conversation viewer are extension-owned Textual widgets (see "The
+agents strip").
 
 ## Use
 
@@ -60,23 +58,22 @@ Ask the model to delegate:
 > Spawn an explore subagent to find where slash commands are registered,
 > run it in the background.
 
-`/agents` manages agents. On Tau builds with the `ui-dialogs` seam it opens
-an interactive menu (ported from pi's showAgentsMenu): selecting a run opens
-its conversation viewer (see "The agents strip"), falling back to a dialog
-submenu (view result / steer / stop) on hosts without the component seam. pi's
-create wizard and settings menu are not ported yet. Without the seam — or
-headless — it prints the plain-text list instead.
+`/agents` manages agents. In the TUI it opens an interactive menu (ported
+from pi's showAgentsMenu): selecting a run opens its conversation viewer (see
+"The agents strip"), falling back to a dialog submenu (view result / steer /
+stop) on hosts without mounted components. pi's create wizard and settings
+menu are not ported yet. Headless (print mode) it prints the plain-text list
+instead.
 
 ## The agents strip
 
-> **Experimental (branch `component-seam-experiment`).** On this branch the
-> whole agent UI is owned by the extension as real Textual widgets
-> (`src/tau_subagents/ui/`), mounted through Tau's generic *component seam*
-> (`context.ui.components`: `set_slot_widget` / `open_main_view` /
-> `register_key_interceptor`) rather than Tau core's older transcript-sources
-> seam. Tau core stays agent-agnostic — it only hosts widgets.
+The whole agent UI is owned by the extension as real Textual widgets
+(`src/tau_subagents/ui/`), mounted through Tau's generic *component seam*
+(`context.ui.components`: `set_slot_widget` / `open_main_view` /
+`register_key_interceptor`). Tau core stays agent-agnostic — it only hosts
+widgets.
 
-On component-capable Tau builds, spawning a subagent shows a strip under the
+In the TUI, spawning a subagent shows a strip under the
 prompt (`AgentStripWidget`) listing `main` plus every queued/running agent (the
 Claude Code pattern). Rows are deliberately quiet: a status glyph (a hollow
 circle while running — the spinner/timer/token stats live on the agent
@@ -214,8 +211,7 @@ that:
   doesn't have to read them on demand. Native discovery is turned off for
   such agents (matching pi, which sets `noSkills` for named preloads so the
   same skill isn't both preloaded and indexed) — the child gets exactly the
-  named skills. Requires the `skills_enabled` seam; against an older Tau the
-  index stays on alongside the preloaded bodies.
+  named skills.
 - `skills: true` (or `*` / `all`) — pins the child's resource discovery
   (skills **and** project context files such as AGENTS.md) to the **parent**
   working directory. This only makes a difference under
@@ -223,11 +219,7 @@ that:
   against the worktree copy — e.g. uncommitted project skills would be
   invisible to the isolated child.
 - `skills: none` / `false` — disables the child's skill discovery entirely
-  (no `<available_skills>` index, no `/skill:` expansion) when Tau supports
-  the `CodingSessionConfig.skills_enabled` seam (tau fork branch
-  `skills-seam`). Against an older Tau without the seam, the extension
-  feature-detects and falls back to the previous behavior: native discovery
-  stays on and this value only skips preloading.
+  (no `<available_skills>` index, no `/skill:` expansion).
 
 In `prompt_mode: append` the parent prompt prefix already carries the
 parent's skill index verbatim.
@@ -286,16 +278,14 @@ notifications (`<total_tokens>`), and the `steer_subagent` confirmation's
 
 Token figures come in two flavors:
 
-- **Real billed tokens** (`<total_tokens>`, `<K> tokens`) — available when Tau
-  has the `provider-usage` seam (branch `provider-usage`; usage fields on
-  `AssistantMessage` populated by the provider adapters). Following pi's
-  semantics, the lifetime total sums `input + output + cache_write` per
-  assistant response; cache *reads* are excluded because each turn re-reads
-  the whole cached prefix, so summing them would count the prefix once per
-  turn (pi issue #38).
+- **Real billed tokens** (`<total_tokens>`, `<K> tokens`) — from the usage
+  fields on `AssistantMessage`, populated by Tau's provider adapters.
+  Following pi's semantics, the lifetime total sums
+  `input + output + cache_write` per assistant response; cache *reads* are
+  excluded because each turn re-reads the whole cached prefix, so summing
+  them would count the prefix once per turn (pi issue #38).
 - **Context estimate** (`~<K> context tokens`, `<context_tokens>`) — Tau's
-  deterministic chars/4 estimate of the child's current context size. Always
-  available; the only token figure on Tau branches without the usage seam.
+  deterministic chars/4 estimate of the child's current context size.
 
 ## Live activity
 
@@ -307,13 +297,11 @@ removed as transcript noise.
 
 ## Notification rendering
 
-On Tau builds with the `message-renderers` seam, background completion
-notifications render as pi-style cards (status icon, bold description, dim
-stats line with turns/tools/tokens/duration, collapsed result preview,
-transcript path) instead of raw `<task-notification>` XML bubbles — the raw
-XML still enters the model's context unchanged. Group notifications stack
-one card per run. Without the seam, notifications arrive as plain user
-messages exactly as before.
+Background completion notifications render as pi-style cards (status icon,
+bold description, dim stats line with turns/tools/tokens/duration, collapsed
+result preview, transcript path) instead of raw `<task-notification>` XML
+bubbles — the raw XML still enters the model's context unchanged. Group
+notifications stack one card per run.
 
 ## Concurrency and the background queue
 
@@ -378,10 +366,6 @@ time, so queued background runs see the conversation as of the tool call.
 Compaction summaries appear as `[User]` turns (Tau folds them into user
 messages during replay) rather than pi's `[Summary]:` framing.
 
-Requires a Tau build with the `parent-context` seam
-(`tau.context.transcript`); without it the tool call fails with an
-explanatory error rather than silently spawning without context.
-
 ## Settings
 
 Settings are read from two JSON files and shallow-merged, project overriding
@@ -407,17 +391,14 @@ default.
   MCP tools — pi's `isolated` param (which strips them) has nothing to strip
   here and is deliberately not ported.
 - Live activity while a subagent works is the spinner + elapsed timer on its
-  tool row and the in-place view (see "Live activity"); on older Tau builds
-  without those seams, runs are silent while they work — prefer background
-  mode for long tasks there.
+  tool row and the in-place view (see "Live activity").
 - `/reload` rebuilds extension state; background runs in flight at reload
   time are orphaned.
 
 ## Tests
 
 The tests need Tau's packages importable. The repo's own environment resolves
-Tau via the path source in `pyproject.toml` (`[tool.uv.sources]` — edit it if
-your Tau checkout lives elsewhere):
+`tau-ai` from PyPI:
 
 ```bash
 uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tau-subagents"
-version = "0.1.0"
+version = "0.2.0"
 description = "Subagents extension for Tau (a port of pi-subagents)."
 readme = "README.md"
 license = "MIT"
@@ -21,13 +21,12 @@ classifiers = [
  "Programming Language :: Python :: 3.14",
 ]
 keywords = ["tau", "subagents", "extension", "agents", "tui"]
-# textual is a direct dependency on the component-seam-experiment branch: the
-# extension's agents strip and conversation viewer are real Textual widgets
-# mounted through tau's component seam (previously it reached textual only
-# transitively via tau).
+# textual is a direct dependency: the extension's agents strip and
+# conversation viewer are real Textual widgets mounted through tau's component
+# seam. The floor matches tau-ai 0.3.0's own textual requirement.
 dependencies = [
- "tau-ai>=0.2.0",
- "textual>=1.0",
+ "tau-ai>=0.3.0",
+ "textual>=8.2.8",
 ]
 
 [project.urls]
@@ -38,9 +37,9 @@ Issues = "https://github.com/rian-dolphin/tau-subagents/issues"
 [dependency-groups]
 dev = ["pytest>=8.0", "anyio>=4.0"]
 
-# Tau extension manifest (tau branch `extension-manifest`, ported from pi's
-# package.json "pi.extensions"): lets `tau -e` on this repo root find the
-# entry inside the src layout, no root shim needed.
+# Tau extension manifest (ported from pi's package.json "pi.extensions"):
+# lets `tau -e` on this repo root find the entry inside the src layout, no
+# root shim needed.
 [tool.tau]
 extensions = ["src/tau_subagents/extension.py"]
 

--- a/src/tau_subagents/agents.py
+++ b/src/tau_subagents/agents.py
@@ -15,9 +15,7 @@ Children discover skills natively through Tau's own machinery by default.
 `skills: <csv>` additionally preloads the named skills' bodies into the
 system prompt; `skills: true`/`*`/`all` pins resource discovery (skills and
 project context files) to the parent cwd, which only matters under worktree
-isolation; `skills: none`/`false` disables skill discovery entirely when Tau
-supports the `skills_enabled` config seam (otherwise it only skips
-preloading).
+isolation; `skills: none`/`false` disables skill discovery entirely.
 """
 
 from __future__ import annotations
@@ -144,8 +142,7 @@ def _parse_skills(raw: str | None) -> tuple[str, ...] | bool | None:
 
     None = omitted (Tau's native discovery, default); tuple = named preload;
     True (`true`/`*`/`all`) = pin discovery to the parent cwd; False
-    (`none`/`false`) = disable skill discovery (needs Tau's skills_enabled
-    seam; otherwise same as omitted).
+    (`none`/`false`) = disable skill discovery.
     """
     if raw is None:
         return None

--- a/src/tau_subagents/agents_menu.py
+++ b/src/tau_subagents/agents_menu.py
@@ -47,12 +47,12 @@ class DialogUi(Protocol):
 
 
 def supports_menu(ui: object) -> bool:
-    """True when the bound UI can drive the interactive menu."""
-    return (
-        ui is not None
-        and bool(getattr(ui, "has_ui", False))
-        and hasattr(ui, "select")
-    )
+    """True when the bound UI can drive the interactive menu.
+
+    ``has_ui`` is a runtime signal, not feature detection: print mode's
+    NullUiBridge reports False, and /agents falls back to the plain-text list.
+    """
+    return ui is not None and bool(getattr(ui, "has_ui", False))
 
 
 async def show_agents_menu(
@@ -128,7 +128,7 @@ def view_run_conversation(
     With a component-capable host the extension opens its own conversation
     viewer (the widget seam that replaced tau's removed ``view_transcript``):
     on success the whole menu closes ("exit") so the user lands in the view.
-    Component-less hosts (print mode / older tau) fall to the action submenu
+    Component-less hosts (print mode) fall to the action submenu
     ("actions"), exactly as the old ``view_transcript``-missing branch did.
     """
     if controller is not None:

--- a/src/tau_subagents/extension.py
+++ b/src/tau_subagents/extension.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import dataclasses
-import functools
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
@@ -101,14 +99,6 @@ SOFT_LIMIT_MESSAGE = (
     "You have reached your turn limit. Wrap up immediately — provide your"
     " final answer now."
 )
-
-
-@functools.cache
-def _supports_skills_enabled() -> bool:
-    """Whether this Tau has the CodingSessionConfig.skills_enabled seam."""
-    return "skills_enabled" in {
-        config_field.name for config_field in dataclasses.fields(CodingSessionConfig)
-    }
 
 
 class _MemoryStorage:
@@ -594,11 +584,8 @@ class SubagentManager:
         extra_config: dict[str, bool] = {}
         # skills: none/false disables skill discovery; a named CSV also
         # disables it so preloaded bodies aren't double-listed in the index
-        # (pi sets noSkills for both). Requires the skills_enabled seam;
-        # otherwise fall back to default discovery.
-        if (
-            definition.skills is False or isinstance(definition.skills, tuple)
-        ) and _supports_skills_enabled():
+        # (pi sets noSkills for both).
+        if definition.skills is False or isinstance(definition.skills, tuple):
             extra_config["skills_enabled"] = False
         session = await CodingSession.load(
             CodingSessionConfig(
@@ -811,17 +798,13 @@ class SubagentManager:
     def _deliver_notification(
         self, content: str, details: dict[str, object]
     ) -> None:
-        """Send via the message-renderers seam when present, else raw."""
-        send_custom = getattr(self._api, "send_custom_message", None)
-        if send_custom is not None:
-            send_custom(
-                content,
-                custom_type="subagent-notification",
-                details=details,
-                deliver_as="follow_up",
-            )
-        else:
-            self._api.send_user_message(content, deliver_as="follow_up")
+        """Send as a custom message so the registered renderer draws the card."""
+        self._api.send_custom_message(
+            content,
+            custom_type="subagent-notification",
+            details=details,
+            deliver_as="follow_up",
+        )
 
 
 def _effective_max_turns(
@@ -1028,10 +1011,9 @@ def render_steer_call(arguments: Mapping[str, object]) -> str:
 def setup(tau: ExtensionAPI) -> None:
     """Register subagent tools, the /agents command, and shutdown cleanup."""
     manager = SubagentManager(tau)
-    if hasattr(tau, "register_message_renderer"):
-        # message-renderers seam: notifications render as pi-style cards
-        # instead of raw <task-notification> XML bubbles.
-        tau.register_message_renderer("subagent-notification", render_notification)
+    # Notifications render as pi-style cards instead of raw
+    # <task-notification> XML bubbles.
+    tau.register_message_renderer("subagent-notification", render_notification)
     scheduler = SubagentScheduler(manager)
 
     def start_scheduler() -> None:
@@ -1048,7 +1030,7 @@ def setup(tau: ExtensionAPI) -> None:
         except Exception:  # noqa: BLE001 - scheduling must never break the session
             pass
 
-    # Component seam (experimental): the extension owns the agents strip and the
+    # Component seam: the extension owns the agents strip and the
     # conversation viewer as Textual widgets mounted through the component
     # bridge. Installed lazily on session_start — NOT in setup() — because the
     # host attaches its UI bridge (making supports_components True) only after
@@ -1056,11 +1038,11 @@ def setup(tau: ExtensionAPI) -> None:
     ui_controller: list[object] = []  # 0 or 1 element (a nonlocal-friendly cell)
 
     def _install_ui_components() -> None:
-        # getattr-guard keeps the extension loadable on an older tau without the
-        # component seam (constraint 8): it then runs dialog-only, no strip.
-        components = getattr(getattr(tau, "context", None), "ui", None)
-        components = getattr(components, "components", None)
-        if components is None or not getattr(components, "supports_components", False):
+        # supports_components is a runtime gate, not feature detection: the
+        # print-mode NullUiBridge reports False, and the extension then runs
+        # dialog-only, no strip.
+        components = tau.context.ui.components
+        if not components.supports_components:
             return
         # Defensive reinstall (bug fix 2): a controller can survive into the next
         # bind if a session_start arrives without a matching shutdown (or the host
@@ -1120,17 +1102,7 @@ def setup(tau: ExtensionAPI) -> None:
         if inherit:
             # Captured at spawn time (pi semantics): the digest reflects the
             # parent conversation as of this tool call, even for queued runs.
-            context = getattr(tau, "context", None)
-            transcript = (
-                getattr(context, "transcript", None) if context is not None else None
-            )
-            if transcript is None:
-                return _tool_result(
-                    content="inherit_context requires a Tau build with the"
-                    " parent-context seam (the parent transcript is not"
-                    " exposed to extensions here).",
-                )
-            parent_context = build_parent_context(transcript)
+            parent_context = build_parent_context(tau.context.transcript)
             if parent_context:
                 prompt = parent_context + prompt
         model = str(arguments.get("model")) if arguments.get("model") else None
@@ -1398,7 +1370,7 @@ def setup(tau: ExtensionAPI) -> None:
 
     def agents_command(args: str, context) -> str | None:  # noqa: ANN001
         del args, context
-        ui = getattr(getattr(tau, "context", None), "ui", None)
+        ui = tau.context.ui
         if supports_menu(ui):
             try:
                 loop = asyncio.get_running_loop()

--- a/src/tau_subagents/ui/__init__.py
+++ b/src/tau_subagents/ui/__init__.py
@@ -1,11 +1,10 @@
 """Extension-owned Textual widgets for the subagents fleet UI.
 
-This package is the extension side of tau's *component seam* (branch
-``component-seam-experiment``): the agents strip and the conversation viewer
-that used to live in tau core are now real Textual ``Widget``s that the
-extension mounts through ``context.ui.components``. Importing ``textual`` (and,
-in the viewer, a couple of tau TUI internals) directly is the deliberate
-coupling this experiment measures.
+This package is the extension side of tau's *component seam*: the agents strip
+and the conversation viewer are real Textual ``Widget``s that the extension
+mounts through ``context.ui.components``. It imports ``textual`` (and, in the
+viewer, a couple of tau TUI internals) directly — a deliberate coupling to the
+host's rendering, called out where it happens.
 """
 
 from __future__ import annotations

--- a/src/tau_subagents/ui/viewer.py
+++ b/src/tau_subagents/ui/viewer.py
@@ -7,10 +7,9 @@ view — NOT a modal — so the fleet strip stays visible for peripheral awarene
 Rendering deliberately REUSES tau core's own transcript internals rather than
 reinventing them: it feeds a :class:`tau_coding.tui.state.TuiState` (via
 ``load_messages``) into a :class:`tau_coding.tui.widgets.TranscriptView` and
-calls ``update_from_state`` — exactly the ``TuiState`` + ``#agent-transcript-pane``
-mechanics tau core's ``_activate_source``/``_tick_agent_view`` used before this
-migration. Importing those host internals is the coupling this experiment
-measures; it is called out here because it is non-obvious.
+calls ``update_from_state``, so subagent transcripts render pixel-identical to
+the main chat. Importing those host internals is a deliberate coupling; it is
+called out here because it is non-obvious.
 
 Live updates are push, not poll: the viewer subscribes to the run's listener
 registry on mount and unsubscribes on unmount (the analog of pi's

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1430,35 +1430,6 @@ async def test_named_skills_preload_disables_native_index(tmp_path: Path) -> Non
     assert "<available_skills>" not in system  # pi: named preload sets noSkills
 
 
-async def test_skills_none_falls_back_without_seam(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    runtime = _load_runtime(tmp_path)
-    runtime.bind(RecordingSession(tmp_path))
-    module = _extension_module()
-    (tmp_path / ".tau" / "skills" / "idxskill").mkdir(parents=True)
-    (tmp_path / ".tau" / "skills" / "idxskill" / "SKILL.md").write_text(
-        "---\ndescription: Indexed skill\n---\nDo indexed things."
-    )
-    (tmp_path / ".tau" / "agents").mkdir(exist_ok=True)
-    (tmp_path / ".tau" / "agents" / "noskills.md").write_text(
-        "---\ndescription: No skills\nskills: none\n---\nBody."
-    )
-    monkeypatch.setattr(module, "_supports_skills_enabled", lambda: False)
-    provider = FakeProvider([_text_stream("done")])
-    _patch_provider_factory(module, provider)
-
-    agent_tool = _agent_tool(runtime)
-    result = await agent_tool.execute(
-        "call-1",
-        {"prompt": "x", "description": "x", "subagent_type": "noskills"}
-    )
-
-    # Against an older Tau without the seam, the spawn still works and
-    # native discovery stays on.
-    assert "<name>idxskill</name>" in provider.calls[0][1]
-
-
 async def test_usage_surfaced_in_results_and_notifications(tmp_path: Path) -> None:
     runtime = _load_runtime(tmp_path)
     session = RecordingSession(tmp_path)

--- a/tests/test_integration_tui.py
+++ b/tests/test_integration_tui.py
@@ -31,6 +31,7 @@ from tau_coding.events import QueueUpdateEvent
 from tau_agent.messages import AssistantMessage
 from tau_ai import AssistantDoneEvent, AssistantStartEvent, FakeProvider
 from tau_coding.session import ModelChoice, TerminalCommandResult
+from tau_coding.session_stats import SessionStats
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tools import create_coding_tools
@@ -101,6 +102,8 @@ class _FakeSession:
         self.available_thinking_levels = ("off", "low", "medium", "high")
         self.state = _FakeSessionState()
         self.resource_diagnostics = ()
+        self.extension_names = ("subagents",)
+        self.session_stats = SessionStats()
         self.system_prompt = "You are Tau."
         self.session_manager = None
         self._session_title: str | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -348,14 +348,14 @@ dependencies = [
     { name = "textual" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/e5/bc2822acc28ca37d17b3ef5571c5e270798400f1cccabe7546c3b842054e/tau_ai-0.2.0.tar.gz", hash = "sha256:965602065e58b95b4252288c881443cc49ac9e768c25a6b9d2be5241d7667153", size = 742498, upload-time = "2026-07-16T15:50:30.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/7b/693e22efe3bd936b9a6cc1d7e81bb27e755bb93732dea233411d8c043e61/tau_ai-0.3.0.tar.gz", hash = "sha256:cbf0cc1646a71d30ccb895871f5e7f70bc8a96684bbd0264bc8b9d5195f117d5", size = 808143, upload-time = "2026-07-22T11:39:25.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/96/a4699d6606066d9ad6b0efa467f14e9778161d99127be516fe5c09301596/tau_ai-0.2.0-py3-none-any.whl", hash = "sha256:c96cc47ae7239b6040b8a31b8468da405f967e365d91dd49b150b472ab3f76be", size = 302165, upload-time = "2026-07-16T15:50:29.611Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/10/7f7dc9e87f7a97adbfe1d518ad24e4f0e3d1a110fad06131c95bbcad690c/tau_ai-0.3.0-py3-none-any.whl", hash = "sha256:75d5d18c304ea696a693e3b0e6c3a67c77ad512015f7cb1beff5fd31eac39a78", size = 334988, upload-time = "2026-07-22T11:39:23.653Z" },
 ]
 
 [[package]]
 name = "tau-subagents"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tau-ai" },
@@ -370,8 +370,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "tau-ai", specifier = ">=0.2.0" },
-    { name = "textual", specifier = ">=1.0" },
+    { name = "tau-ai", specifier = ">=0.3.0" },
+    { name = "textual", specifier = ">=8.2.8" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Updates the extension for upstream tau-ai 0.3.0 (released 2026-07-22), supporting the latest version only. The upstream extension API is unchanged between 0.2.0 and 0.3.0, and 0.3.0's breaking change (CLI flag mirror of pi: `-x` → `-e`, `-o/--output` → `--mode`) doesn't affect an in-process extension — so this is mostly deletion of compatibility archaeology (net −79 lines).

### Compat guards removed (all unconditionally present in 0.3.0)

- `hasattr(tau, "register_message_renderer")` — now registered directly
- `send_custom_message` getattr with `send_user_message` fallback — both funnel through the same follow-up delivery path upstream, so semantics are unchanged
- getattr chains reaching `context.ui.components`, `context.transcript`, `context.ui`
- `hasattr(ui, "select")` in the /agents menu gate
- `_supports_skills_enabled()` dataclass-field probe and its without-seam fallback test (`skills: none` behavior remains covered by `test_skills_none_disables_native_discovery`)

Deliberately **kept**: the `supports_components` and `has_ui` gates (runtime print-mode signals, not version detection), the viewer's `tui_settings` getattr (test-host guard), and duck-typing getattrs over heterogeneous message shapes.

### Test fix

tau's new sidebar session insights make the TUI read `session.session_stats`, so the integration tests' `_FakeSession` gains `session_stats` and `extension_names`, mirroring upstream's own `FakeSession`.

### Packaging

- `tau-ai>=0.2.0` → `>=0.3.0` (required for correctness once the guards are gone; no upper cap)
- `textual>=1.0` → `>=8.2.8`, matching tau 0.3.0's own floor for a direct dependency
- extension version 0.1.0 → 0.2.0 to signal dropped 0.2.x support

### Docs

README and code comments de-archaeologized: the "targets 0.2.0, read seam mentions as historical" preamble, `component-seam-experiment` / `ui-dialogs` / `skills-seam` / `provider-usage` branch references, and the stale `[tool.uv.sources]` claim are replaced with plain descriptions of current behavior.

Also verified as needing no code reaction: thinking persistence on assistant event streams (tau #371), data-driven themes (#374 — loaded themes are validated to carry every role style the viewer reads), provider error recovery (#395), and the session-JSONL Unicode fix (#354).

## Test plan

- [x] `uv run pytest` — 133 passed against tau-ai 0.3.0 (includes real-TUI integration tests mounting tau's actual `TauTuiApp`)
- [x] `uvx ruff check src` — clean
- [x] `uv lock --check` — lockfile consistent with the new floors